### PR TITLE
`?godbolt` - add missing line break

### DIFF
--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -225,7 +225,7 @@ pub async fn godbolt(
 	let text =
 		crate::helpers::merge_output_and_errors(&godbolt_result.output, &godbolt_result.stderr);
 	let note = if code.code.contains("pub fn") {
-		"Note: only public functions (`pub fn`) are shown"
+		"Note: only public functions (`pub fn`) are shown\n"
 	} else {
 		""
 	};


### PR DESCRIPTION
Adding a `\n` at the end of the `note` would, when the message gets truncated, separate the note itself and the 'Output too large. Godbolt link: ...' message. And, in the case the note would happen to be at the end of the message, Discord trims trailing newlines.

I'm pretty sure this should work but haven't actually tested it.