### PR TITLE
added MODMAIL_CHANNEL_ID to template

### DIFF
--- a/Secrets.dev.toml.template
+++ b/Secrets.dev.toml.template
@@ -13,5 +13,8 @@ MOD_ROLE_ID=""
 # ID of the Rustacean role. Used for `?rustify` command
 RUSTACEAN_ROLE_ID=""
 
+# ID of the channel to send modmail to
+MODMAIL_CHANNEL_ID=""
+
 # The duration to wait before refreshing the godbolt targets list
 GODBOLT_UPDATE_DURATION="1"


### PR DESCRIPTION
in my testing, the field being absent prevents the bot from starting, so it should probably be in the template.