### PR TITLE
Fix /selftimeout parameter handling

### DIFF
--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -232,8 +232,8 @@ pub async fn ban(
 )]
 pub async fn selftimeout(
 	ctx: Context<'_>,
-	#[description = "Duration of self-timeout in hours"] duration_in_hours: Option<i64>,
-	#[description = "Duration of self-timeout in minutes"] duration_in_minutes: Option<i64>,
+	#[description = "Duration of self-timeout in hours"] duration_in_hours: Option<u64>,
+	#[description = "Duration of self-timeout in minutes"] duration_in_minutes: Option<u64>,
 ) -> Result<(), Error> {
 	let total_seconds = match (duration_in_hours, duration_in_minutes) {
 		(None, None) => 3600, // When nothing is specified, default to one hour.
@@ -242,7 +242,7 @@ pub async fn selftimeout(
 
 	let now = ctx.created_at().unix_timestamp();
 
-	let then = Timestamp::from_unix_timestamp(now + total_seconds)?;
+	let then = Timestamp::from_unix_timestamp(now + total_seconds as i64)?;
 
 	let mut member = ctx
 		.author_member()

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -237,7 +237,10 @@ pub async fn selftimeout(
 ) -> Result<(), Error> {
 	let duration = {
 		let hours = duration_in_hours.unwrap_or(0);
-		let minutes = duration_in_minutes.unwrap_or(60);
+		let minutes = duration_in_minutes.unwrap_or(match hours {
+			0 => 60,
+			_ => 0,
+		});
 
 		if hours < 0 || minutes < 0 {
 			return Err(anyhow!("duration must be positive"));


### PR DESCRIPTION
Problem: when using `/selftimeout`, if you *only* specify the duration in hours, then an unexpected extra hour is added to the time.

Result: pain and suffering. I have to wait an extra hour before ~~being offtopic in general~~ participating in productive conversations.

Solution: match on the `hours` value when minutes isn't specified. If it's `0`, then the current default (60) is still used. If it's nonzero, use 0 instead.