### PR TITLE
Missing code block error now uses code blocks itself

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,11 +102,13 @@ async fn poise(#[shuttle_secrets::Secrets] secret_store: SecretStore) -> Shuttle
 						let response = if error.is::<poise::CodeBlockError>() {
 							"\
 Missing code block. Please use the following markdown:
-\\`code here\\`
+`` `code here` ``
 or
-\\`\\`\\`rust
+```ansi
+`\x1b[0m`\x1b[0m`rust
 code here
-\\`\\`\\`"
+`\x1b[0m`\x1b[0m`
+```"
 								.to_owned()
 						} else if let Some(multiline_help) = ctx.command().help_text {
 							format!("**{}**\n{}", error, multiline_help())


### PR DESCRIPTION
The missing code block error now uses code blocks to nicely format the error message:

## Old output
![Old output](https://github.com/rust-community-discord/ferrisbot-for-discord/assets/23159282/e08cb1b4-4f86-4a32-ac99-6b4e27381380)

## New output
![New output](https://github.com/rust-community-discord/ferrisbot-for-discord/assets/23159282/58c166a3-2c82-4777-9d78-2c9cf81a136c)
