### PR TITLE
Improved error message when bot can't enter modmail channel

### DIFF
--- a/src/commands/modmail.rs
+++ b/src/commands/modmail.rs
@@ -98,7 +98,8 @@ pub async fn load_or_create_modmail_message(
 	let modmail_guild_channel = data
 		.modmail_channel_id
 		.to_channel(http.as_ref())
-		.await?
+		.await
+		.map_err(|e| anyhow!(e).context("Cannot enter modmail channel"))?
 		.guild()
 		.ok_or(anyhow!("This command can only be used in a guild"))?;
 


### PR DESCRIPTION
If you forgot to give the bot access to the modmail channel you entered in `Secrets.toml`, the error message wouldn't help you to figure out what went wrong.

Previous error that was inscrutable:

> 024-01-09T14:32:02.131-05:00 [Runtime]  WARN chaitrex_ferrisbot_test: Encountered error: Setup { error: Missing Access

New error message:

> 2024-01-09T14:28:38.710-05:00 [Runtime]  WARN chaitrex_ferrisbot_test: Encountered error: Setup { error: Cannot enter modmail channel, …
