### PR TITLE
fix: ignore Unknown Message error

### DIFF
--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -290,10 +290,11 @@ pub async fn send_reply(
 		ctx.rerun().await?;
 	} else {
 		// If timed out, just remove the button
-		response
+		// Errors are ignored in case the reply was deleted
+		let _ = response
 			// TODO: Add code to remove button
 			.edit(ctx, |create_reply| create_reply)
-			.await?;
+			.await;
 	}
 
 	Ok(())


### PR DESCRIPTION
Currently, Ferris attempts to edit the reply after the timeout of 600 seconds. However, if Ferris' response has been deleted, this will cause an Unknown Message error. To fix this, errors from editing the message will be ignored.