### PR TITLE
fix #27 breaking emojis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,18 +2447,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/commands/playground/misc_commands.rs
+++ b/src/commands/playground/misc_commands.rs
@@ -23,8 +23,8 @@ pub async fn miri(
 	let code = &maybe_wrapped(
 		&code.code,
 		ResultHandling::Discard,
-		ctx.prefix().contains("sweat"),
-		ctx.prefix().contains("owo"),
+		ctx.prefix().contains("Sweat"),
+		ctx.prefix().contains("OwO") || ctx.prefix().contains("Cat"),
 	);
 	let (flags, flag_parse_errors) = parse_flags(flags);
 
@@ -149,7 +149,7 @@ pub async fn clippy(
 		maybe_wrapped(
 			&code.code,
 			ResultHandling::Discard,
-			ctx.prefix().contains("sweat"),
+			ctx.prefix().contains("Sweat"),
 			false,
 		)
 	);

--- a/src/commands/playground/play_eval.rs
+++ b/src/commands/playground/play_eval.rs
@@ -17,8 +17,8 @@ async fn play_or_eval(
 	let code = maybe_wrapped(
 		&code.code,
 		result_handling,
-		ctx.prefix().contains("sweat"),
-		ctx.prefix().contains("owo"),
+		ctx.prefix().contains("Sweat"),
+		ctx.prefix().contains("OwO") || ctx.prefix().contains("Cat"),
 	);
 	let (mut flags, flag_parse_errors) = parse_flags(flags);
 

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -221,7 +221,7 @@ pub fn maybe_wrapped(
 			let stmts = Block::parse_within(input)?;
 			for stmt in &stmts {
 				if let Stmt::Item(Item::Fn(ItemFn { sig, .. })) = stmt {
-					if sig.ident.to_string() == "main" && sig.inputs.len() == 0 {
+					if sig.ident == "main" && sig.inputs.is_empty() {
 						return Err(input.error("main"));
 					}
 				}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,12 +84,12 @@ async fn serenity(#[shuttle_runtime::Secrets] secret_store: SecretStore) -> Shut
 					poise::Prefix::Literal("🦀"),
 					poise::Prefix::Literal("<:ferris:358652670585733120> "),
 					poise::Prefix::Literal("<:ferris:358652670585733120>"),
-					poise::Prefix::Literal("<:sweat:678714352450142239> "),
-					poise::Prefix::Literal("<:sweat:678714352450142239>"),
-					poise::Prefix::Literal("<:owo:678714352450142239> "),
-					poise::Prefix::Literal("<:owo:678714352450142239>"),
-					poise::Prefix::Literal("<:owo:579331467000283136> "),
-					poise::Prefix::Literal("<:owo:579331467000283136>"),
+					poise::Prefix::Literal("<:ferrisballSweat:678714352450142239> "),
+					poise::Prefix::Literal("<:ferrisballSweat:678714352450142239>"),
+					poise::Prefix::Literal("<:ferrisCat:678714352450142239> "),
+					poise::Prefix::Literal("<:ferrisCat:678714352450142239>"),
+					poise::Prefix::Literal("<:ferrisOwO:579331467000283136> "),
+					poise::Prefix::Literal("<:ferrisOwO:579331467000283136>"),
 					poise::Prefix::Regex(
 						"(yo |hey )?(crab|ferris|fewwis),? can you (please |pwease )?"
 							.parse()


### PR DESCRIPTION
so while discord renders emojis `<a:$emoji_id>` just fine poises matcher thing does not, and therefore I sort of broke the emoji based commands.