### PR TITLE
Allow edition 2024 on playground

### DIFF
--- a/src/commands/playground/api.rs
+++ b/src/commands/playground/api.rs
@@ -141,6 +141,8 @@ pub enum Edition {
 	E2018,
 	#[serde(rename = "2021")]
 	E2021,
+	#[serde(rename = "2024")]
+	E2024,
 }
 
 impl FromStr for Edition {
@@ -151,6 +153,7 @@ impl FromStr for Edition {
 			"2015" => Ok(Edition::E2015),
 			"2018" => Ok(Edition::E2018),
 			"2021" => Ok(Edition::E2021),
+			"2024" => Ok(Edition::E2024),
 			_ => bail!("invalid edition `{}`", s),
 		}
 	}
@@ -265,6 +268,7 @@ pub fn url_from_gist(flags: &CommandFlags, gist_id: &str) -> String {
 			Edition::E2015 => "2015",
 			Edition::E2018 => "2018",
 			Edition::E2021 => "2021",
+			Edition::E2024 => "2024",
 		},
 		gist_id
 	)

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -92,7 +92,7 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
 		reply += "- mode: debug, release (default: debug)\n";
 		reply += "- channel: stable, beta, nightly (default: nightly)\n";
 	}
-	reply += "- edition: 2015, 2018, 2021 (default: 2021)\n";
+	reply += "- edition: 2015, 2018, 2021, 2024 (default: 2021)\n";
 	if spec.warn {
 		reply += "- warn: true, false (default: false)\n";
 	}


### PR DESCRIPTION
Playground now supports 2024 edition in dropdown. This PR enables the bot to use 2024 edition.

Example here:
https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=ec174b3bb8eb2b158e857379fdec9e0c

I think I got everything, but let me know if more needs to be done.