### PR TITLE
Use godbolt's colour output via ANSI codeblocks

### DIFF
--- a/src/commands/modmail.rs
+++ b/src/commands/modmail.rs
@@ -1,4 +1,3 @@
-use crate::commands::modmail;
 use crate::types::{Context, Data};
 use anyhow::{anyhow, Error};
 use poise::serenity_prelude as serenity;

--- a/src/commands/playground/api.rs
+++ b/src/commands/playground/api.rs
@@ -54,7 +54,6 @@ pub struct FormatRequest<'a> {
 pub struct FormatResponse {
 	pub success: bool,
 	pub code: String,
-	pub stdout: String,
 	pub stderr: String,
 }
 

--- a/src/commands/playground/misc_commands.rs
+++ b/src/commands/playground/misc_commands.rs
@@ -24,7 +24,6 @@ pub async fn miri(
 		&code.code,
 		ResultHandling::Discard,
 		ctx.prefix().contains("Sweat"),
-		ctx.prefix().contains("OwO") || ctx.prefix().contains("Cat"),
 	);
 	let (flags, flag_parse_errors) = parse_flags(flags);
 
@@ -150,7 +149,6 @@ pub async fn clippy(
 			&code.code,
 			ResultHandling::Discard,
 			ctx.prefix().contains("Sweat"),
-			false,
 		)
 	);
 	let (flags, flag_parse_errors) = parse_flags(flags);

--- a/src/commands/playground/play_eval.rs
+++ b/src/commands/playground/play_eval.rs
@@ -14,12 +14,7 @@ async fn play_or_eval(
 ) -> Result<(), Error> {
 	ctx.say(stub_message(ctx)).await?;
 
-	let code = maybe_wrapped(
-		&code.code,
-		result_handling,
-		ctx.prefix().contains("Sweat"),
-		ctx.prefix().contains("OwO") || ctx.prefix().contains("Cat"),
-	);
+	let code = maybe_wrapped(&code.code, result_handling, ctx.prefix().contains("Sweat"));
 	let (mut flags, flag_parse_errors) = parse_flags(flags);
 
 	if force_warnings {

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -198,27 +198,18 @@ pub fn hoise_crate_attributes(code: &str, after_crate_attrs: &str, after_code: &
 /// To check, whether a wrap was done, check if the return type is Cow::Borrowed vs Cow::Owned
 /// If a wrap was done, also hoists crate attributes to the top so they keep working
 pub fn maybe_wrap(code: &str, result_handling: ResultHandling) -> Cow<str> {
-	maybe_wrapped(code, result_handling, false, false)
+	maybe_wrapped(code, result_handling, false)
 }
 
-pub fn maybe_wrapped(
-	code: &str,
-	result_handling: ResultHandling,
-	unsf: bool,
-	pretty: bool,
-) -> Cow<str> {
-	use quote::quote;
+pub fn maybe_wrapped(code: &str, result_handling: ResultHandling, unsf: bool) -> Cow<str> {
 	use syn::{parse::Parse, *};
 
 	// We use syn to check whether there is a main function.
-	struct Inline {
-		attrs: Vec<Attribute>,
-		stmts: Vec<Stmt>,
-	}
+	struct Inline {}
 
 	impl Parse for Inline {
 		fn parse(input: parse::ParseStream) -> Result<Self> {
-			let attrs = Attribute::parse_inner(input)?;
+			Attribute::parse_inner(input)?;
 			let stmts = Block::parse_within(input)?;
 			for stmt in &stmts {
 				if let Stmt::Item(Item::Fn(ItemFn { sig, .. })) = stmt {
@@ -227,7 +218,7 @@ pub fn maybe_wrapped(
 					}
 				}
 			}
-			Ok(Self { attrs, stmts })
+			Ok(Self {})
 		}
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::commands::modmail;
 use crate::commands::modmail::{create_modmail_thread, load_or_create_modmail_message};
 use crate::types::Data;
 use anyhow::{anyhow, Error};
 use poise::serenity_prelude as serenity;
-use poise::serenity_prelude::{EditThread, Mentionable};
 use rand::{seq::IteratorRandom, thread_rng, Rng};
 use shuttle_runtime::SecretStore;
 use shuttle_serenity::ShuttleSerenity;
@@ -213,12 +211,14 @@ async fn event_handler(
 		tokio::spawn(init_server_icon_changer(http, data.discord_guild_id));
 	}
 
-	if let serenity::FullEvent::InteractionCreate { interaction, .. } = event {
-		if let serenity::Interaction::Component(component) = interaction {
-			if component.data.custom_id == "rplcs_create_new_modmail" {
-				let message = "Created from modmail button";
-				create_modmail_thread(ctx, message, data, component.user.id).await?;
-			}
+	if let serenity::FullEvent::InteractionCreate {
+		interaction: serenity::Interaction::Component(component),
+		..
+	} = event
+	{
+		if component.data.custom_id == "rplcs_create_new_modmail" {
+			let message = "Created from modmail button";
+			create_modmail_thread(ctx, message, data, component.user.id).await?;
 		}
 	}
 


### PR DESCRIPTION
This fixes the godbolt command as godbolt has never officially supported passing `--color`. Instead of stripping the ANSI sequences as previously done, we can now just use discord's ANSI codeblock rendering.