### PR TITLE
fixes the pretty printing that `:ferrisCat: eval` should cause

### DIFF
--- a/src/commands/playground/misc_commands.rs
+++ b/src/commands/playground/misc_commands.rs
@@ -33,6 +33,7 @@ pub async fn miri(
 		&code.code,
 		ResultHandling::Discard,
 		ctx.prefix().contains("Sweat"),
+		false,
 	);
 	let (flags, flag_parse_errors) = parse_flags(flags);
 
@@ -160,6 +161,7 @@ pub async fn clippy(
 			&code.code,
 			ResultHandling::Discard,
 			ctx.prefix().contains("Sweat"),
+			false,
 		)
 	);
 	let (flags, flag_parse_errors) = parse_flags(flags);

--- a/src/commands/playground/play_eval.rs
+++ b/src/commands/playground/play_eval.rs
@@ -20,7 +20,12 @@ async fn play_or_eval(
 ) -> Result<(), Error> {
 	ctx.say(stub_message(ctx)).await?;
 
-	let code = maybe_wrapped(&code.code, result_handling, ctx.prefix().contains("Sweat"));
+	let code = maybe_wrapped(
+		&code.code,
+		result_handling,
+		ctx.prefix().contains("Sweat"),
+		ctx.prefix().contains("OwO") || ctx.prefix().contains("Cat"),
+	);
 	let (mut flags, flag_parse_errors) = parse_flags(flags);
 
 	if force_warnings {

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -200,11 +200,17 @@ pub fn hoise_crate_attributes(code: &str, after_crate_attrs: &str, after_code: &
 /// To check, whether a wrap was done, check if the return type is `Cow::Borrowed` vs `Cow::Owned`
 /// If a wrap was done, also hoists crate attributes to the top so they keep working
 pub fn maybe_wrap(code: &str, result_handling: ResultHandling) -> Cow<'_, str> {
-	maybe_wrapped(code, result_handling, false)
+	maybe_wrapped(code, result_handling, false, false)
 }
 
-pub fn maybe_wrapped(code: &str, result_handling: ResultHandling, unsf: bool) -> Cow<'_, str> {
-	use syn::{parse, parse::Parse, parse_str, Attribute, Block, Item, ItemFn, Result, Stmt};
+pub fn maybe_wrapped(
+	code: &str,
+	result_handling: ResultHandling,
+	unsf: bool,
+	pretty: bool,
+) -> Cow<'_, str> {
+	#[allow(clippy::wildcard_imports)]
+	use syn::{parse::Parse, *};
 
 	// We use syn to check whether there is a main function.
 	struct Inline {}
@@ -235,6 +241,7 @@ pub fn maybe_wrapped(code: &str, result_handling: ResultHandling, unsf: bool) ->
 	let mut after_crate_attrs = match result_handling {
 		ResultHandling::None => "fn main() {\n",
 		ResultHandling::Discard => "fn main() { let _ = {\n",
+		ResultHandling::Print if pretty => "fn main() { println!(\"{:#?}\", {\n",
 		ResultHandling::Print => "fn main() { println!(\"{:?}\", {\n",
 	}
 	.to_owned();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/39c9a035-55ee-46e7-b661-e2c8b4bf21ba)


was broken by #30 