### PR TITLE
Default to 2024 edition

### DIFF
--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -295,7 +295,7 @@ fn parse(args: &str) -> Result<(KeyValueArgs, String), CodeBlockError> {
 /// ``​`
 /// ```
 /// Optional arguments:
-/// - `flag*`: flags to pass to rustc invocation. Defaults to {"-Copt-level=3", "--edition=2021"}
+/// - `flag*`: flags to pass to rustc invocation. Defaults to {"-Copt-level=3", "--edition=2024"}
 /// - `rustc`: compiler version to invoke. Defaults to `nightly`. Possible values: `nightly`, `beta` or full version like `1.45.2`
 #[poise::command(prefix_command, category = "Godbolt", broadcast_typing, track_edits)]
 pub async fn godbolt(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Error> {
@@ -325,7 +325,7 @@ pub async fn godbolt(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), 
 /// ``​`
 /// ```
 /// Optional arguments:
-/// - `flag*`: flags to pass to rustc invocation. Defaults to {"-Copt-level=3", "--edition=2021"}
+/// - `flag*`: flags to pass to rustc invocation. Defaults to {"-Copt-level=3", "--edition=2024"}
 /// - `rustc`: compiler version to invoke. Defaults to `nightly`. Possible values: `nightly`, `beta` or full version like `1.45.2`
 #[poise::command(prefix_command, category = "Godbolt", broadcast_typing, track_edits)]
 pub async fn mca(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Error> {
@@ -358,7 +358,7 @@ pub async fn mca(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Erro
 /// ``​`
 /// ```
 /// Optional arguments:
-/// - `flag*`: flags to pass to rustc invocation. Defaults to {"-Copt-level=3", "--edition=2021", "--emit=llvm-ir", "-Cdebuginfo=0"}
+/// - `flag*`: flags to pass to rustc invocation. Defaults to {"-Copt-level=3", "--edition=2024", "--emit=llvm-ir", "-Cdebuginfo=0"}
 /// - `rustc`: compiler version to invoke. Defaults to `nightly`. Possible values: `nightly`, `beta` or full version like `1.45.2`
 #[poise::command(prefix_command, category = "Godbolt", broadcast_typing, track_edits)]
 pub async fn llvmir(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Error> {

--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -254,7 +254,7 @@ fn parse(args: &str) -> Result<(KeyValueArgs, String), CodeBlockError> {
 			}
 			' ' => {
 				map.insert(take(&mut key), take(&mut value));
-				k = true
+				k = true;
 			}
 			'=' => k = false,
 			c if k => key.push(c),

--- a/src/commands/godbolt/targets.rs
+++ b/src/commands/godbolt/targets.rs
@@ -148,7 +148,7 @@ pub(crate) async fn rustc_id_and_flags(
             Run ?targets for a full list"))?;
 
 	let opt_level = params.get("-Copt-level").unwrap_or("3");
-	let edition = params.get("--edition").unwrap_or("2021");
+	let edition = params.get("--edition").unwrap_or("2024");
 	let flags = itertools::Itertools::intersperse(params
 		.0
 		.iter()

--- a/src/commands/playground/procmacro.rs
+++ b/src/commands/playground/procmacro.rs
@@ -82,7 +82,7 @@ fn main() -> std::io::Result<()> {
 			channel: Channel::Nightly, // so that inner proc macro gets nightly too
 			// These flags only apply to the glue code
 			crate_type: CrateType::Binary,
-			edition: Edition::E2021,
+			edition: Edition::E2024,
 			mode: Mode::Debug,
 			tests: false,
 		})

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -27,7 +27,7 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 	let mut flags = api::CommandFlags {
 		channel: api::Channel::Nightly,
 		mode: api::Mode::Debug,
-		edition: api::Edition::E2021,
+		edition: api::Edition::E2024,
 		warn: false,
 		run: false,
 	};
@@ -93,7 +93,7 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
 		reply += "- mode: debug, release (default: debug)\n";
 		reply += "- channel: stable, beta, nightly (default: nightly)\n";
 	}
-	reply += "- edition: 2015, 2018, 2021, 2024 (default: 2021)\n";
+	reply += "- edition: 2015, 2018, 2021, 2024 (default: 2024)\n";
 	if spec.warn {
 		reply += "- warn: true, false (default: false)\n";
 	}


### PR DESCRIPTION
Since 2024 edition was just released, we can now default to it.

I believe I got everything, but please do a double check just to make sure. Let me know if there are any other thoughts.

Also, one note that as of this current comment date, godbolt has not _yet_ upgraded to 1.85 (I'm sure they will soon), so technically godbolt will be broken for a short time if this is merged before they update