### PR TITLE
Added checking for `#[unsafe(no_mangle)]` and `#[inline(never)]` in the ?godbolt command

### DIFF
--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -169,10 +169,10 @@ enum GodboltMode {
 }
 
 fn note(code: &str) -> &'static str {
-	if code.contains("#[no_mangle]") {
+	if code.contains("#[no_mangle]") || code.contains("#[unsafe(no_mangle)]") || code.contains("#[inline(never)]") {
 		""
 	} else {
-		"Note: only unmangled functions (`#[no_mangle] pub fn`) are shown"
+		"Note: only unmangled functions or public no-inline functions (`#[unsafe(no_mangle)] pub fn` or `#[inline(never)] pub fn`) are shown"
 	}
 }
 


### PR DESCRIPTION
What the title says, im not sure if `#[inline(never)]` should be mentioned or if its too long