### PR TITLE
Get a better response

### DIFF
--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -144,8 +144,7 @@ pub async fn conradluget(
 
 	let attachment = serenity::CreateAttachment::bytes(img_bytes, filename);
 
-	ctx.channel_id()
-		.send_files(ctx, vec![attachment], serenity::CreateMessage::new())
+	ctx.send(poise::CreateReply::default().attachment(attachment))
 		.await?;
 
 	Ok(())


### PR DESCRIPTION
Idk how discord bots work but I imagine this fixes the command reply stuff. I took inspiration from the `/crate` or `?crate` commands, which also uses `ctx.send()` and I know works as expected.