### PR TITLE
Add `/man` command (similar to crate and docs)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,6 +3,7 @@ pub use playground::*;
 
 pub mod crates;
 pub mod godbolt;
+pub mod man;
 pub mod modmail;
 pub mod playground;
 pub mod thread_pin;

--- a/src/commands/man.rs
+++ b/src/commands/man.rs
@@ -1,0 +1,48 @@
+use anyhow::bail;
+use anyhow::Result;
+use reqwest::header;
+
+use crate::serenity;
+use crate::types::Context;
+
+const USER_AGENT: &str = "kangalioo/rustbot";
+
+#[poise::command(prefix_command, slash_command, category = "Utilities")]
+pub async fn man(
+	ctx: Context<'_>,
+	#[description = "Section of the man page"] section: Option<String>,
+	#[description = "Name of the man page"] man_page: String,
+) -> Result<()> {
+	let section = section.unwrap_or_else(|| "1".to_owned());
+
+	let mut url = format!("https://manpages.debian.org/{section}/{man_page}");
+
+	if let Ok(response) = ctx
+		.data()
+		.http
+		.get(&url)
+		.header(header::USER_AGENT, USER_AGENT)
+		.send()
+		.await
+	{
+		if response.status() == 404 {
+			bail!("Man page not found");
+		}
+	} else {
+		bail!("Failed to fetch man page");
+	}
+
+	url.push_str(".html");
+
+	ctx.send(
+		poise::CreateReply::default().embed(
+			serenity::CreateEmbed::new()
+				.title(format!("man {section} {man_page}"))
+				.url(&url)
+				.color(crate::types::EMBED_COLOR),
+		),
+	)
+	.await?;
+
+	Ok(())
+}

--- a/src/commands/man.rs
+++ b/src/commands/man.rs
@@ -13,12 +13,6 @@ const USER_AGENT: &str = "kangalioo/rustbot";
 	broadcast_typing,
 	category = "Utilities"
 )]
-#[poise::command(
-	prefix_command,
-	slash_command,
-	broadcast_typing,
-	category = "Utilities"
-)]
 pub async fn man(
 	ctx: Context<'_>,
 	#[description = "Section of the man page"] section: Option<String>,
@@ -58,14 +52,6 @@ pub async fn man(
 				.title(format!("man {man_page}({section})"))
 				.description(format!("View the man page for `{man_page}` on the web"))
 				.url(&url)
-				.color(crate::types::EMBED_COLOR)
-				.footer(serenity::CreateEmbedFooter::new(
-					"Powered by manpages.debian.org",
-				))
-				.thumbnail("https://www.debian.org/logos/openlogo-nd-100.jpg")
-				.field("Section", &section, true)
-				.field("Page", &man_page, true)
-				.timestamp(serenity::Timestamp::now()),
 				.color(crate::types::EMBED_COLOR)
 				.footer(serenity::CreateEmbedFooter::new(
 					"Powered by manpages.debian.org",

--- a/src/commands/man.rs
+++ b/src/commands/man.rs
@@ -7,13 +7,23 @@ use crate::types::Context;
 
 const USER_AGENT: &str = "kangalioo/rustbot";
 
-#[poise::command(prefix_command, slash_command, category = "Utilities")]
+#[poise::command(
+	prefix_command,
+	slash_command,
+	broadcast_typing,
+	category = "Utilities"
+)]
 pub async fn man(
 	ctx: Context<'_>,
 	#[description = "Section of the man page"] section: Option<String>,
 	#[description = "Name of the man page"] man_page: String,
 ) -> Result<()> {
 	let section = section.unwrap_or_else(|| "1".to_owned());
+
+	// Make sure that the section is a valid number
+	if !section.parse::<u8>().is_ok() {
+		bail!("Invalid section number");
+	}
 
 	let mut url = format!("https://manpages.debian.org/{section}/{man_page}");
 
@@ -26,10 +36,12 @@ pub async fn man(
 		.await
 	{
 		if response.status() == 404 {
-			bail!("Man page not found");
+			ctx.say("Man page not found.").await?;
+			return Ok(());
 		}
 	} else {
-		bail!("Failed to fetch man page");
+		ctx.say("Failed to fetch man page.").await?;
+		return Ok(());
 	}
 
 	url.push_str(".html");
@@ -37,9 +49,17 @@ pub async fn man(
 	ctx.send(
 		poise::CreateReply::default().embed(
 			serenity::CreateEmbed::new()
-				.title(format!("man {section} {man_page}"))
+				.title(format!("man {man_page}({section})"))
+				.description(format!("View the man page for `{man_page}` on the web"))
 				.url(&url)
-				.color(crate::types::EMBED_COLOR),
+				.color(crate::types::EMBED_COLOR)
+				.footer(serenity::CreateEmbedFooter::new(
+					"Powered by manpages.debian.org",
+				))
+				.thumbnail("https://www.debian.org/logos/openlogo-nd-100.jpg")
+				.field("Section", &section, true)
+				.field("Page", &man_page, true)
+				.timestamp(serenity::Timestamp::now()),
 		),
 	)
 	.await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ code here
 		})
 		.options(poise::FrameworkOptions {
 			commands: vec![
+				commands::man::man(),
 				commands::crates::crate_(),
 				commands::crates::doc(),
 				commands::godbolt::godbolt(),


### PR DESCRIPTION
Closes #13.

I initially planned to implement pagination and man page traversal using the `tuff-parser` crate while parsing the man files located at `/usr/share/man/`. However, I found it unnecessary since opening a website is significantly faster than scrolling through a paginated man page.

Screenshots:
![image](https://github.com/user-attachments/assets/ef2a1d24-7f99-4198-9fd3-2e6a7c20bd6f)
![image](https://github.com/user-attachments/assets/8bad5934-8a21-42c3-80b9-54b0427937f7)
![image](https://github.com/user-attachments/assets/98231428-5182-452a-9377-a968f1e32322)
![image](https://github.com/user-attachments/assets/6564463b-2221-4e30-a355-bad84aa89ccd)


Copilot Summary:
This pull request introduces a new `man` command to the project, which allows users to fetch and display man pages from the Debian website. The changes involve adding a new module, defining the command, and integrating it into the main command list.

New `man` command integration:

* [`src/commands.rs`](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520R6): Added a new module `man` to the list of public modules.
* [`src/commands/man.rs`](diffhunk://#diff-7d7bc422a1500868decdf32473953544f273c1f26cfc7e00f0d8865fe37c86caR1-R63): Implemented the `man` command, which fetches and displays man pages from the Debian website using the `reqwest` library and `poise` framework.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR77): Integrated the new `man` command into the main command list.