### PR TITLE
Attempt to resolve an exact link for ?doc items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ name = "ferrisbot-for-discord"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "image",
  "imageproc",
  "itertools 0.12.1",
@@ -827,12 +828,13 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -841,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -851,15 +853,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -879,15 +881,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -896,21 +898,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ rusttype = { version = "0.9", default-features = false } # interact with imagepr
 rand = "0.8.5"
 syn = { version = "2.0.68", features = ["full"] }
 itertools = "0.12.0"
+futures = "0.3.31"

--- a/src/commands/crates/tests.rs
+++ b/src/commands/crates/tests.rs
@@ -1,0 +1,120 @@
+struct MockDocsClient;
+
+impl super::DocsClient for MockDocsClient {
+	async fn page_exists(&self, url: &str) -> bool {
+		match url {
+			"https://doc.rust-lang.org/stable/std/char/constant.MAX.html"
+			| "https://docs.rs/serde-json/latest/serde_json/fn.to_string.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/trait.Index.html" => true,
+			"https://doc.rust-lang.org/stable/std/char/static.MAX.html"
+			| "https://docs.rs/serde-json/latest/serde_json/macro.to_string.html"
+			| "https://docs.rs/serde-json/latest/serde_json/to_string/index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/macro.value.html"
+			| "https://docs.rs/serde-json/latest/serde_json/fn.value.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/struct.Index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/enum.Index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/union.Index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/traitalias.Index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/type.Index.html"
+			| "https://docs.rs/serde-json/latest/serde_json/value/derive.Index.html" => false,
+			_ if url.starts_with("https://docs.rs/serde-json/latest/serde_json/non/existent") => {
+				false
+			}
+			_ => panic!("unexpected query {url:?}"),
+		}
+	}
+
+	async fn get_crate_docs(&self, crate_name: &str) -> anyhow::Result<String> {
+		match crate_name {
+			"serde-json" => Ok("https://docs.rs/serde-json".to_owned()),
+			_ => panic!("unexpected query {crate_name:?}"),
+		}
+	}
+}
+
+#[tokio::test]
+async fn path_to_doc_url_stable_std() {
+	test_path_to_doc_url("std", "https://doc.rust-lang.org/stable/std/").await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_self_ty() {
+	test_path_to_doc_url(
+		"Self",
+		"https://doc.rust-lang.org/stable/std/keyword.SelfTy.html",
+	)
+	.await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_std_primitive() {
+	test_path_to_doc_url(
+		"f128",
+		"https://doc.rust-lang.org/nightly/std/primitive.f128.html",
+	)
+	.await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_nightly_std() {
+	test_path_to_doc_url("nightly", "https://doc.rust-lang.org/nightly/std/").await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_stable_guessed_const() {
+	test_path_to_doc_url(
+		"std::char::MAX",
+		"https://doc.rust-lang.org/stable/std/char/constant.MAX.html",
+	)
+	.await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_crate_docs() {
+	test_path_to_doc_url("serde-json", "https://docs.rs/serde-json").await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_guessed_fn() {
+	test_path_to_doc_url(
+		"serde-json::to_string",
+		"https://docs.rs/serde-json/latest/serde_json/fn.to_string.html",
+	)
+	.await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_guessed_mod() {
+	test_path_to_doc_url(
+		"serde-json::value",
+		"https://docs.rs/serde-json/latest/serde_json/value/index.html",
+	)
+	.await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_guessed_trait() {
+	test_path_to_doc_url(
+		"serde-json::value::Index",
+		"https://docs.rs/serde-json/latest/serde_json/value/trait.Index.html",
+	)
+	.await;
+}
+
+#[tokio::test]
+async fn path_to_doc_url_search() {
+	test_path_to_doc_url(
+		"serde-json::non::existent::symbol",
+		"https://docs.rs/serde-json?search=non::existent::symbol",
+	)
+	.await;
+}
+
+async fn test_path_to_doc_url(path: &str, expect: &str) {
+	assert_eq!(
+		super::path_to_doc_url(path, &MockDocsClient).await.unwrap(),
+		expect,
+		"{path} should resolve to {expect}",
+	);
+}


### PR DESCRIPTION
When given a qualified path for the ?doc command, test the item kind by brute forcing each possible path concurrently through a HEAD request. A fast path first tests the "usual" variants based on the snake/pascal/screaming-snake case of the identifier, then fallback to other less likely types upon failure. A 2xx response from the documentation server is considered a positive response.

When multiple items with the same name (e.g. trait + derive macro) are present, whichever gets returned depends on luck (whichever the server responds more quickly and gets picked up by `FuturesUnordered`).
![image](https://github.com/user-attachments/assets/8fd416a0-f5aa-4974-97a2-c84609730d47)
This can be controlled by writing `?doc trait@bevy::prelude::Component` instead.

Falls back to the old `?search=` response when the item cannot be found. This is especially useful for non-inline re-exports, such as `tokio::spawn`.

Also updated the list of std primitives and keywords for completeness. Added the special case of `Self` to resolve into `SelfTy`.