### PR TITLE
highlight `--emit=mir` and `--emit=llvmir` sort of things properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ syn = { version = "2.0.100", features = ["full"] }
 itertools = "0.14"
 futures = "0.3.31"
 proc-macro2 = { version = "1.0.94", features = ["span-locations"] }
+implicit-fn = "0.1.0"


### PR DESCRIPTION
previously it just used `x86asm` by default all the time, which sucked for arm
![image](https://github.com/user-attachments/assets/197ea18f-2b08-4551-bc27-122cd7ac6271)
