### PR TITLE
Feat: Add support for Tree borrows with miri

### DIFF
--- a/src/commands/playground/api.rs
+++ b/src/commands/playground/api.rs
@@ -14,6 +14,7 @@ pub struct CommandFlags {
 	pub edition: Edition,
 	pub warn: bool,
 	pub run: bool,
+	pub aliasing_model: AliasingModel,
 }
 
 #[derive(Debug, Serialize)]
@@ -30,11 +31,15 @@ pub struct PlaygroundRequest<'a> {
 #[derive(Debug, Serialize)]
 pub struct MiriRequest<'a> {
 	pub edition: Edition,
+	pub aliasing_model: AliasingModel,
 	pub code: &'a str,
 }
 
-// has the same fields
-pub type MacroExpansionRequest<'a> = MiriRequest<'a>;
+#[derive(Debug, Serialize)]
+pub struct MacroExpansionRequest<'a> {
+	pub edition: Edition,
+	pub code: &'a str,
+}
 
 #[derive(Debug, Serialize)]
 pub struct ClippyRequest<'a> {
@@ -183,6 +188,25 @@ impl FromStr for Mode {
 			"release" => Ok(Mode::Release),
 			_ => bail!("invalid compilation mode `{}`", s),
 		}
+	}
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AliasingModel {
+	Stacked,
+	Tree,
+}
+
+impl FromStr for AliasingModel {
+	type Err = Error;
+
+	fn from_str(s: &str) -> Result<Self, Error> {
+		Ok(match s {
+			"stacked" => AliasingModel::Stacked,
+			"tree" => AliasingModel::Tree,
+			_ => bail!("invalid aliasing model `{}`", s),
+		})
 	}
 }
 

--- a/src/commands/playground/api.rs
+++ b/src/commands/playground/api.rs
@@ -31,6 +31,7 @@ pub struct PlaygroundRequest<'a> {
 #[derive(Debug, Serialize)]
 pub struct MiriRequest<'a> {
 	pub edition: Edition,
+	#[serde(rename = "aliasingModel")]
 	pub aliasing_model: AliasingModel,
 	pub code: &'a str,
 }

--- a/src/commands/playground/microbench.rs
+++ b/src/commands/playground/microbench.rs
@@ -153,6 +153,7 @@ that should be opaque to the optimizer: `number * 2` produces optimized integer 
 		mode_and_channel: false,
 		warn: true,
 		run: false,
+		aliasing_model: false,
 		example_code: "
 pub fn add() {
     black_box(black_box(42.0) + black_box(99.0));

--- a/src/commands/playground/misc_commands.rs
+++ b/src/commands/playground/misc_commands.rs
@@ -44,6 +44,7 @@ pub async fn miri(
 		.json(&MiriRequest {
 			code,
 			edition: flags.edition,
+			aliasing_model: flags.aliasing_model,
 		})
 		.send()
 		.await?
@@ -70,6 +71,7 @@ pub fn miri_help() -> String {
 		// Playgrounds sends miri warnings/errors and output in the same field so we can't filter
 		// warnings out
 		warn: false,
+		aliasing_model: true,
 		run: false,
 		example_code: "code",
 	})
@@ -135,6 +137,7 @@ pub fn expand_help() -> String {
 		mode_and_channel: false,
 		warn: false,
 		run: false,
+		aliasing_model: false,
 		example_code: "code",
 	})
 }
@@ -203,6 +206,7 @@ pub fn clippy_help() -> String {
 		mode_and_channel: false,
 		warn: false,
 		run: false,
+		aliasing_model: false,
 		example_code: "code",
 	})
 }
@@ -241,6 +245,7 @@ pub fn fmt_help() -> String {
 		desc: "Format code using rustfmt",
 		mode_and_channel: false,
 		warn: false,
+		aliasing_model: false,
 		run: false,
 		example_code: "code",
 	})

--- a/src/commands/playground/play_eval.rs
+++ b/src/commands/playground/play_eval.rs
@@ -77,6 +77,7 @@ pub fn play_help() -> String {
 		mode_and_channel: true,
 		warn: true,
 		run: false,
+		aliasing_model: false,
 		example_code: "code",
 	})
 }
@@ -104,6 +105,7 @@ pub fn playwarn_help() -> String {
 		mode_and_channel: true,
 		warn: false,
 		run: false,
+		aliasing_model: false,
 		example_code: "code",
 	})
 }
@@ -131,6 +133,7 @@ pub fn eval_help() -> String {
 		mode_and_channel: true,
 		warn: true,
 		run: false,
+		aliasing_model: false,
 		example_code: "code",
 	})
 }

--- a/src/commands/playground/procmacro.rs
+++ b/src/commands/playground/procmacro.rs
@@ -112,6 +112,7 @@ proc-macro code, and one for the usage code which can refer to the proc-macro cr
 		mode_and_channel: false,
 		warn: true,
 		run: true,
+		aliasing_model: false,
 		example_code: "
 #[proc_macro]
 pub fn foo(_: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -30,6 +30,7 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 		edition: api::Edition::E2024,
 		warn: false,
 		run: false,
+		aliasing_model: api::AliasingModel::Stacked,
 	};
 
 	macro_rules! pop_flag {
@@ -48,6 +49,7 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 	pop_flag!("edition", flags.edition);
 	pop_flag!("warn", flags.warn);
 	pop_flag!("run", flags.run);
+	pop_flag!("aliasing_model", flags.aliasing_model);
 
 	for (remaining_flag, _) in args.0 {
 		errors += &format!("unknown flag `{remaining_flag}`\n");
@@ -63,6 +65,7 @@ pub struct GenericHelp<'a> {
 	pub mode_and_channel: bool,
 	pub warn: bool,
 	pub run: bool,
+	pub aliasing_model: bool,
 	pub example_code: &'a str,
 }
 
@@ -78,6 +81,9 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
 		reply += " mode={} channel={}";
 	}
 	reply += " edition={}";
+	if spec.aliasing_model {
+		reply += " aliasing_model={}";
+	}
 	if spec.warn {
 		reply += " warn={}";
 	}
@@ -92,6 +98,9 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
 	if spec.mode_and_channel {
 		reply += "- mode: debug, release (default: debug)\n";
 		reply += "- channel: stable, beta, nightly (default: nightly)\n";
+	}
+	if spec.aliasing_model {
+		reply += "- aliasing_model: stacked, tree (default: stacked)\n";
 	}
 	reply += "- edition: 2015, 2018, 2021, 2024 (default: 2024)\n";
 	if spec.warn {


### PR DESCRIPTION
Mostly self explanatory change. I think this should work, but I haven't tested the bot or anything locally. I'm not sure if you'd prefer a different way to do the help message when only one command takes a flag, but this seemed to be most consistent. 

Also, I wasn't sure if Ferris should take in the flag as `aliasing_model` or `aliasingModel`. This would be the first two word flag, so not sure if you prefer one way or another. I'd be happy to change to camel case if you want. Thanks!