### PR TITLE
Fix: Miri Tree Borrows aliasingModel camel cased and appease clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
  "futures",
  "image",
  "imageproc",
+ "implicit-fn",
  "itertools 0.14.0",
  "poise",
  "proc-macro2",
@@ -1369,6 +1370,17 @@ dependencies = [
  "num",
  "rand 0.8.5",
  "rand_distr",
+]
+
+[[package]]
+name = "implicit-fn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "837f3904739ddc022e28e667c09a2118bd7480c79a771e90f79d56d1db7b36cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -233,7 +233,7 @@ async fn respond_codeblocks(
 			)
 			.await?;
 		}
-	};
+	}
 	Ok(())
 }
 

--- a/src/commands/man.rs
+++ b/src/commands/man.rs
@@ -21,7 +21,7 @@ pub async fn man(
 	let section = section.unwrap_or_else(|| "1".to_owned());
 
 	// Make sure that the section is a valid number
-	if !section.parse::<u8>().is_ok() {
+	if section.parse::<u8>().is_err() {
 		bail!("Invalid section number");
 	}
 

--- a/src/commands/playground/microbench.rs
+++ b/src/commands/playground/microbench.rs
@@ -91,7 +91,7 @@ pub async fn microbench(
 			return Ok(());
 		}
 		_ => {}
-	};
+	}
 
 	// insert this after user code
 	let mut after_code = BENCH_FUNCTION.to_owned();
@@ -160,9 +160,8 @@ pub fn mul() {
 }
 
 fn extract_pub_fn_names_from_user_code(code: &str) -> Vec<String> {
-	let file = match parse_file(code) {
-		Ok(file) => file,
-		Err(_) => return vec![],
+	let Ok(file) = parse_file(code) else {
+		return vec![];
 	};
 
 	file.items

--- a/src/commands/playground/microbench.rs
+++ b/src/commands/playground/microbench.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use core::fmt::Write as _;
 use syn::{parse_file, Item, ItemFn, Visibility};
 
 use crate::types::Context;
@@ -97,7 +98,8 @@ pub async fn microbench(
 	let mut after_code = BENCH_FUNCTION.to_owned();
 	after_code += "fn main() {\nbench(&[";
 	for function_name in pub_fn_names {
-		after_code += &format!("(\"{function_name}\", {function_name}),\n");
+		writeln!(after_code, "(\"{function_name}\", {function_name}),")
+			.expect("Writing to a String should never fail");
 	}
 	after_code += "]);\n}\n";
 

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -49,7 +49,7 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 	pop_flag!("edition", flags.edition);
 	pop_flag!("warn", flags.warn);
 	pop_flag!("run", flags.run);
-	pop_flag!("aliasing_model", flags.aliasing_model);
+	pop_flag!("aliasingModel", flags.aliasing_model);
 
 	for (remaining_flag, _) in args.0 {
 		errors += &format!("unknown flag `{remaining_flag}`\n");
@@ -82,7 +82,7 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
 	}
 	reply += " edition={}";
 	if spec.aliasing_model {
-		reply += " aliasing_model={}";
+		reply += " aliasingModel={}";
 	}
 	if spec.warn {
 		reply += " warn={}";
@@ -100,7 +100,7 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
 		reply += "- channel: stable, beta, nightly (default: nightly)\n";
 	}
 	if spec.aliasing_model {
-		reply += "- aliasing_model: stacked, tree (default: stacked)\n";
+		reply += "- aliasingModel: stacked, tree (default: stacked)\n";
 	}
 	reply += "- edition: 2015, 2018, 2021, 2024 (default: 2024)\n";
 	if spec.warn {

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -1,3 +1,4 @@
+use core::fmt::Write as _;
 use std::borrow::Cow;
 
 use poise::serenity_prelude as serenity;
@@ -38,7 +39,9 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 			if let Some(flag) = args.0.remove($flag_name) {
 				match flag.parse() {
 					Ok(x) => $flag_field = x,
-					Err(e) => errors += &format!("{}\n", e),
+					Err(e) => {
+						writeln!(errors, "{e}").expect("Writing to a String should never fail")
+					}
 				}
 			}
 		};
@@ -52,7 +55,8 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 	pop_flag!("aliasingModel", flags.aliasing_model);
 
 	for (remaining_flag, _) in args.0 {
-		errors += &format!("unknown flag `{remaining_flag}`\n");
+		writeln!(errors, "unknown flag `{remaining_flag}`")
+			.expect("Writing to a String should never fail");
 	}
 
 	(flags, errors)

--- a/src/commands/playground/util.rs
+++ b/src/commands/playground/util.rs
@@ -58,6 +58,7 @@ pub fn parse_flags(mut args: poise::KeyValueArgs) -> (api::CommandFlags, String)
 	(flags, errors)
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Copy)]
 pub struct GenericHelp<'a> {
 	pub command: &'a str,


### PR DESCRIPTION
Poise doesn't allow keys to contain special characters without enclosing them in quotes, so this changes `aliasing_model` to be camelCased (also makes it much easier to use on mobile!). I tested this locally, so it should work now.

I also fixed Clippy in separate commits. The `format_push_string` lint is a bit contentious since it requires handling an error that should never occur. I fixed that in a separate commit, so if you'd prefer not doing that I can revert the commit and disable that lint.