### PR TITLE
Remove presence intents

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,10 @@ code here
 		})
 		.build();
 
-	let intents = serenity::GatewayIntents::all();
+	// Don't include presence updates, as they consume a lot of memory and CPU.
+	let intents = serenity::GatewayIntents::non_privileged() 
+		| serenity::GatewayIntents::GUILD_MEMBERS 
+		| serenity::GatewayIntents::MESSAGE_CONTENT;
 
 	let client = serenity::ClientBuilder::new(token, intents)
 		.framework(framework)


### PR DESCRIPTION
Bot was using excessive amounts of memory and CPU, causing issues, and most of that is due to the heavy load caused by consuming presence updates. Since we don't need those anyway, this should mitigate issues.