### PR TITLE
feat: add purge command

### DIFF
--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -426,7 +426,12 @@ pub async fn purge(
 
 	ctx.defer_ephemeral().await?;
 	messages_to_delete.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-	for message in messages_to_delete.iter().take(amount as usize) {
+	let messages_to_delete = messages_to_delete.iter().take(amount as usize);
+	if amount as usize > messages_to_delete.len() {
+		ctx.say("Not enough messages to delete, deleting as many as possible.")
+			.await?;
+	}
+	for message in messages_to_delete {
 		debug!(message_id = ?message.id, "Deleting message");
 		message.delete(ctx.http()).await?;
 	}

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -392,25 +392,18 @@ pub async fn edit(
 }
 
 /// Deletes messages from a channel, optionally by a user
-#[poise::command(ephemeral, slash_command, prefix_command, category = "Utilities")]
+#[poise::command(
+	ephemeral,
+	slash_command,
+	prefix_command,
+	category = "Utilities",
+	required_permissions = "MANAGE_MESSAGES"
+)]
 pub async fn purge(
 	ctx: Context<'_>,
 	#[description = "User to delete messages from"] user: Option<serenity::User>,
 	#[description = "Amount of messages to delete"] amount: u8,
 ) -> Result<(), Error> {
-	if let Some(member) = ctx.author_member().await {
-		if let Some(permissions) = member.permissions
-			&& !permissions.manage_messages()
-		{
-			ctx.say("You do not have permission to use this command.")
-				.await?;
-			return Ok(());
-		}
-	} else {
-		ctx.say("Could not retrieve your permissions.").await?;
-		return Ok(());
-	}
-
 	let channel_id = ctx.channel_id();
 	let fetch_amount = if user.is_some() { 100 } else { amount };
 	let builder = GetMessages::new().limit(fetch_amount);

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -399,6 +399,19 @@ pub async fn purge(
 	#[description = "User to delete messages from"] user: Option<serenity::User>,
 	#[description = "Amount of messages to delete"] amount: u8,
 ) -> Result<(), Error> {
+	if let Some(member) = ctx.author_member().await {
+		if let Some(permissions) = member.permissions
+			&& !permissions.manage_messages()
+		{
+			ctx.say("You do not have permission to use this command.")
+				.await?;
+			return Ok(());
+		}
+	} else {
+		ctx.say("Could not retrieve your permissions.").await?;
+		return Ok(());
+	}
+
 	let channel_id = ctx.channel_id();
 	let fetch_amount = if user.is_some() { 100 } else { amount };
 	let builder = GetMessages::new().limit(fetch_amount);

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -402,8 +402,13 @@ pub async fn edit(
 pub async fn purge(
 	ctx: Context<'_>,
 	#[description = "User to delete messages from"] user: Option<serenity::User>,
-	#[description = "Amount of messages to delete"] amount: u8,
+	#[description = "Amount of messages to delete (<= 100)"] amount: u8,
 ) -> Result<(), Error> {
+	if amount > 100 {
+		ctx.say("Amount is capped to 100 messages due to a Discord limitation. Please try again.")
+			.await?;
+		return Ok(());
+	}
 	let channel_id = ctx.channel_id();
 	let fetch_amount = if user.is_some() { 100 } else { amount };
 	let builder = GetMessages::new().limit(fetch_amount);

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -7,7 +7,6 @@ use poise::serenity_prelude::{
 };
 use rand::Rng;
 use std::time::Duration;
-use tracing::debug;
 
 use crate::types::Context;
 
@@ -431,11 +430,9 @@ pub async fn purge(
 		ctx.say("Not enough messages to delete, deleting as many as possible.")
 			.await?;
 	}
-	for message in messages_to_delete {
-		debug!(message_id = ?message.id, "Deleting message");
-		message.delete(ctx.http()).await?;
-	}
-
+	channel_id
+		.delete_messages(ctx.http(), messages_to_delete)
+		.await?;
 	let user_str = match user {
 		Some(ref user) => format!("by {}", user.mention()),
 		None => String::new(),

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -402,13 +402,10 @@ pub async fn edit(
 pub async fn purge(
 	ctx: Context<'_>,
 	#[description = "User to delete messages from"] user: Option<serenity::User>,
-	#[description = "Amount of messages to delete (<= 100)"] amount: u8,
+	#[max = 100]
+	#[description = "Amount of messages to delete (<= 100)"]
+	amount: u8,
 ) -> Result<(), Error> {
-	if amount > 100 {
-		ctx.say("Amount is capped to 100 messages due to a Discord limitation. Please try again.")
-			.await?;
-		return Ok(());
-	}
 	let channel_id = ctx.channel_id();
 	let fetch_amount = if user.is_some() { 100 } else { amount };
 	let builder = GetMessages::new().limit(fetch_amount);

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Error, anyhow};
 use poise::serenity_prelude::{
-	self as serenity, ChannelType, EditThread, GetMessages, Mentionable, Timestamp,
+	self as serenity, CacheHttp, ChannelType, EditThread, GetMessages, Mentionable, Timestamp,
 };
 use rand::Rng;
 use std::time::Duration;
@@ -402,32 +402,23 @@ pub async fn edit(
 pub async fn purge(
 	ctx: Context<'_>,
 	#[description = "User to delete messages from"] user: Option<serenity::User>,
-	#[max = 100]
-	#[description = "Amount of messages to delete (<= 100)"]
-	amount: u8,
+	#[description = "Amount of messages to delete"] amount: u8,
 ) -> Result<(), Error> {
 	let channel_id = ctx.channel_id();
-	let fetch_amount = if user.is_some() { 100 } else { amount };
-	let builder = GetMessages::new().limit(fetch_amount);
-	let messages = channel_id.messages(ctx.http(), builder).await?;
 	let mut messages_to_delete = match user {
-		Some(ref user) => messages
-			.into_iter()
-			.filter(|m| m.author.id == user.id)
-			.collect(),
-		None => messages,
+		Some(ref user) => get_messages_from_user(user.clone(), amount, &ctx).await?,
+		None => get_n_messages(amount, &ctx).await?,
 	};
 
 	ctx.defer_ephemeral().await?;
-	messages_to_delete.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-	let messages_to_delete = messages_to_delete.iter().take(amount as usize);
 	if amount as usize > messages_to_delete.len() {
 		ctx.say("Not enough messages to delete, deleting as many as possible.")
 			.await?;
 	}
-	channel_id
-		.delete_messages(ctx.http(), messages_to_delete)
-		.await?;
+	let chunks = messages_to_delete.chunks(100);
+	for chunk in chunks {
+		channel_id.delete_messages(&ctx, chunk).await?;
+	}
 	let user_str = match user {
 		Some(ref user) => format!("by {}", user.mention()),
 		None => String::new(),
@@ -436,4 +427,68 @@ pub async fn purge(
 	ctx.say(format!("Deleted {amount} messages {user_str}"))
 		.await?;
 	Ok(())
+}
+
+async fn get_messages_from_user(
+	user: serenity::User,
+	amount: u8,
+	ctx: &Context<'_>,
+) -> Result<Vec<serenity::Message>, Error> {
+	let channel_id = ctx.channel_id();
+	let mut messages_to_delete = Vec::with_capacity(amount as usize);
+	while messages_to_delete.len() < amount as usize {
+		let messages = channel_id
+			.messages(ctx.http(), GetMessages::new().limit(100))
+			.await?;
+
+		if messages.is_empty() {
+			break; // No more messages to fetch
+		}
+
+		let user_messages: Vec<serenity::Message> = messages
+			.into_iter()
+			.filter(|m| m.author.id == user.id)
+			.collect();
+
+		messages_to_delete.extend(user_messages);
+	}
+
+	todo!()
+}
+
+async fn get_n_messages(amount: u8, ctx: &Context<'_>) -> Result<Vec<serenity::Message>, Error> {
+	let channel_id = ctx.channel_id();
+	if amount <= 100 {
+		let messages = channel_id
+			.messages(ctx.http(), GetMessages::new().limit(amount))
+			.await?;
+		return Ok(messages);
+	}
+
+	// Fetch messages in batches of 100 until we have enough
+	let q = amount / 100;
+	let r = amount % 100;
+	let mut messages_to_delete = Vec::with_capacity(amount as usize);
+	let mut last_message_id = None;
+	for _ in 0..q {
+		let mut builder = GetMessages::new().limit(100);
+		if let Some(last_id) = last_message_id {
+			builder = builder.before(last_id);
+		}
+		let messages = channel_id.messages(ctx.http(), builder).await?;
+		if messages.is_empty() {
+			break; // No more messages to fetch
+		}
+		last_message_id = messages.last().map(|m| m.id);
+		messages_to_delete.extend(messages);
+	}
+	if r > 0 {
+		let mut builder = GetMessages::new().limit(r);
+		if let Some(last_id) = last_message_id {
+			builder = builder.before(last_id);
+		}
+		let messages = channel_id.messages(ctx.http(), builder).await?;
+		messages_to_delete.extend(messages);
+	}
+	Ok(messages_to_delete)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@ fn build_command_list(enable_database: bool) -> Vec<poise::Command<Data, Error>>
 		commands::utilities::uptime(),
 		commands::utilities::conradluget(),
 		commands::utilities::cleanup(),
+		commands::utilities::purge(),
 		commands::utilities::ban(),
 		commands::utilities::selftimeout(),
 		commands::utilities::solved(),


### PR DESCRIPTION
Adds a purge command that deletes `{amount}` messages, optionally from a user. I have tested this locally on a dummy server, and it works correctly.

closes #50 