### PR TITLE
Add info commands `?user <id>` and `?server`

### DIFF
--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -1,154 +1,157 @@
+use anyhow::{Error, anyhow};
+use poise::{
+    CreateReply,
+    serenity_prelude::{self as serenity, ChannelType, Color, CreateEmbed, EditThread, Timestamp},
+};
+use rand::Rng;
 use std::iter;
 use std::sync::LazyLock;
-
-use anyhow::{Error, anyhow};
-use poise::serenity_prelude::{self as serenity, ChannelType, EditThread, Timestamp};
-use rand::Rng;
 use std::time::Duration;
+use tracing::info;
 
 use crate::types::Context;
 
 /// Evaluates Go code
 #[poise::command(
-	prefix_command,
-	slash_command,
-	category = "Utilities",
-	discard_spare_arguments
+    prefix_command,
+    slash_command,
+    category = "Utilities",
+    discard_spare_arguments
 )]
 pub async fn go(ctx: Context<'_>) -> Result<(), Error> {
-	if rand::rng().random_bool(0.01) {
-		ctx.say("Yes").await?;
-	} else {
-		ctx.say("No").await?;
-	}
-	Ok(())
+    if rand::rng().random_bool(0.01) {
+        ctx.say("Yes").await?;
+    } else {
+        ctx.say("No").await?;
+    }
+    Ok(())
 }
 
 /// Links to the bot GitHub repo
 #[poise::command(
-	prefix_command,
-	slash_command,
-	category = "Utilities",
-	discard_spare_arguments
+    prefix_command,
+    slash_command,
+    category = "Utilities",
+    discard_spare_arguments
 )]
 pub async fn source(ctx: Context<'_>) -> Result<(), Error> {
-	ctx.say("https://github.com/rust-community-discord/ferrisbot-for-discord")
-		.await?;
-	Ok(())
+    ctx.say("https://github.com/rust-community-discord/ferrisbot-for-discord")
+        .await?;
+    Ok(())
 }
 
 /// Show this menu
 #[poise::command(prefix_command, slash_command, category = "Utilities", track_edits)]
 pub async fn help(
-	ctx: Context<'_>,
-	#[description = "Specific command to show help about"]
-	#[autocomplete = "poise::builtins::autocomplete_command"]
-	command: Option<String>,
+    ctx: Context<'_>,
+    #[description = "Specific command to show help about"]
+    #[autocomplete = "poise::builtins::autocomplete_command"]
+    command: Option<String>,
 ) -> Result<(), Error> {
-	let extra_text_at_bottom = "\
+    let extra_text_at_bottom = "\
 You can still use all commands with `?`, even if it says `/` above.
 Type ?help command for more info on a command.
 You can edit your message to the bot and the bot will edit its response.";
 
-	poise::builtins::help(
-		ctx,
-		command.as_deref(),
-		poise::builtins::HelpConfiguration {
-			extra_text_at_bottom,
-			ephemeral: true,
-			..Default::default()
-		},
-	)
-	.await?;
-	Ok(())
+    poise::builtins::help(
+        ctx,
+        command.as_deref(),
+        poise::builtins::HelpConfiguration {
+            extra_text_at_bottom,
+            ephemeral: true,
+            ..Default::default()
+        },
+    )
+    .await?;
+    Ok(())
 }
 
 /// Register slash commands in this guild or globally
 #[poise::command(
-	prefix_command,
-	slash_command,
-	category = "Utilities",
-	hide_in_help,
-	check = "crate::checks::check_is_moderator"
+    prefix_command,
+    slash_command,
+    category = "Utilities",
+    hide_in_help,
+    check = "crate::checks::check_is_moderator"
 )]
 pub async fn register(ctx: Context<'_>) -> Result<(), Error> {
-	poise::builtins::register_application_commands_buttons(ctx).await?;
+    poise::builtins::register_application_commands_buttons(ctx).await?;
 
-	Ok(())
+    Ok(())
 }
 
 /// Tells you how long the bot has been up for
 #[poise::command(prefix_command, slash_command, category = "Utilities")]
 pub async fn uptime(ctx: Context<'_>) -> Result<(), Error> {
-	let uptime = ctx.data().bot_start_time.elapsed();
+    let uptime = ctx.data().bot_start_time.elapsed();
 
-	let div_mod = |a, b| (a / b, a % b);
+    let div_mod = |a, b| (a / b, a % b);
 
-	let seconds = uptime.as_secs();
-	let (minutes, seconds) = div_mod(seconds, 60);
-	let (hours, minutes) = div_mod(minutes, 60);
-	let (days, hours) = div_mod(hours, 24);
+    let seconds = uptime.as_secs();
+    let (minutes, seconds) = div_mod(seconds, 60);
+    let (hours, minutes) = div_mod(minutes, 60);
+    let (days, hours) = div_mod(hours, 24);
 
-	ctx.say(format!("Uptime: {days}d {hours}h {minutes}m {seconds}s"))
-		.await?;
+    ctx.say(format!("Uptime: {days}d {hours}h {minutes}m {seconds}s"))
+        .await?;
 
-	Ok(())
+    Ok(())
 }
 
 /// Use this joke command to have Conrad Ludgate tell you to get something
 ///
 /// Example: `/conradluget a better computer`
 #[poise::command(
-	prefix_command,
-	slash_command,
-	category = "Utilities",
-	track_edits,
-	hide_in_help
+    prefix_command,
+    slash_command,
+    category = "Utilities",
+    track_edits,
+    hide_in_help
 )]
 pub async fn conradluget(
-	ctx: Context<'_>,
-	#[description = "Get what?"]
-	#[rest]
-	text: String,
+    ctx: Context<'_>,
+    #[description = "Get what?"]
+    #[rest]
+    text: String,
 ) -> Result<(), Error> {
-	static BASE_IMAGE: LazyLock<image::DynamicImage> = LazyLock::new(|| {
-		image::ImageReader::with_format(
-			std::io::Cursor::new(&include_bytes!("../../assets/conrad.png")[..]),
-			image::ImageFormat::Png,
-		)
-		.decode()
-		.expect("failed to load image")
-	});
-	static FONT: LazyLock<ab_glyph::FontRef<'_>> = LazyLock::new(|| {
-		ab_glyph::FontRef::try_from_slice(include_bytes!("../../assets/OpenSans.ttf"))
-			.expect("failed to load font")
-	});
+    static BASE_IMAGE: LazyLock<image::DynamicImage> = LazyLock::new(|| {
+        image::ImageReader::with_format(
+            std::io::Cursor::new(&include_bytes!("../../assets/conrad.png")[..]),
+            image::ImageFormat::Png,
+        )
+        .decode()
+        .expect("failed to load image")
+    });
+    static FONT: LazyLock<ab_glyph::FontRef<'_>> = LazyLock::new(|| {
+        ab_glyph::FontRef::try_from_slice(include_bytes!("../../assets/OpenSans.ttf"))
+            .expect("failed to load font")
+    });
 
-	let text = format!("Get {text}");
-	let image = imageproc::drawing::draw_text(
-		&*BASE_IMAGE,
-		image::Rgba([201, 209, 217, 255]),
-		57,
-		286,
-		65.0,
-		&*FONT,
-		&text,
-	);
+    let text = format!("Get {text}");
+    let image = imageproc::drawing::draw_text(
+        &*BASE_IMAGE,
+        image::Rgba([201, 209, 217, 255]),
+        57,
+        286,
+        65.0,
+        &*FONT,
+        &text,
+    );
 
-	let mut img_bytes = Vec::with_capacity(200_000); // preallocate 200kB for the img
-	image::DynamicImage::ImageRgba8(image).write_to(
-		&mut std::io::Cursor::new(&mut img_bytes),
-		image::ImageFormat::Png,
-	)?;
+    let mut img_bytes = Vec::with_capacity(200_000); // preallocate 200kB for the img
+    image::DynamicImage::ImageRgba8(image).write_to(
+        &mut std::io::Cursor::new(&mut img_bytes),
+        image::ImageFormat::Png,
+    )?;
 
-	let filename = text + ".png";
+    let filename = text + ".png";
 
-	let attachment = serenity::CreateAttachment::bytes(img_bytes, filename);
+    let attachment = serenity::CreateAttachment::bytes(img_bytes, filename);
 
-	ctx.send(poise::CreateReply::default().attachment(attachment))
-		.await?;
+    ctx.send(poise::CreateReply::default().attachment(attachment))
+        .await?;
 
-	Ok(())
+    Ok(())
 }
 
 /// Deletes the bot's messages for cleanup
@@ -161,33 +164,33 @@ pub async fn conradluget(
 /// You can specify how many messages to look for. Only the 20 most recent messages within the
 /// channel from the last 24 hours can be deleted.
 #[poise::command(
-	prefix_command,
-	slash_command,
-	category = "Utilities",
-	on_error = "crate::helpers::acknowledge_fail"
+    prefix_command,
+    slash_command,
+    category = "Utilities",
+    on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn cleanup(
-	ctx: Context<'_>,
-	#[description = "Number of messages to delete"] num_messages: Option<usize>,
+    ctx: Context<'_>,
+    #[description = "Number of messages to delete"] num_messages: Option<usize>,
 ) -> Result<(), Error> {
-	let num_messages = num_messages.unwrap_or(1);
+    let num_messages = num_messages.unwrap_or(1);
 
-	let messages_to_delete = ctx
-		.channel_id()
-		.messages(&ctx, serenity::GetMessages::new().limit(20))
-		.await?
-		.into_iter()
-		.filter(|msg| {
-			(msg.author.id == ctx.data().application_id)
-				&& (*ctx.created_at() - *msg.timestamp).num_hours() < 24
-		})
-		.take(num_messages);
+    let messages_to_delete = ctx
+        .channel_id()
+        .messages(&ctx, serenity::GetMessages::new().limit(20))
+        .await?
+        .into_iter()
+        .filter(|msg| {
+            (msg.author.id == ctx.data().application_id)
+                && (*ctx.created_at() - *msg.timestamp).num_hours() < 24
+        })
+        .take(num_messages);
 
-	ctx.channel_id()
-		.delete_messages(&ctx, messages_to_delete)
-		.await?;
+    ctx.channel_id()
+        .delete_messages(&ctx, messages_to_delete)
+        .await?;
 
-	crate::helpers::acknowledge_success(ctx, "rustOk", '👌').await
+    crate::helpers::acknowledge_success(ctx, "rustOk", '👌').await
 }
 
 /// Bans another person
@@ -196,25 +199,25 @@ pub async fn cleanup(
 ///
 /// Bans another person
 #[poise::command(
-	prefix_command,
-	slash_command,
-	category = "Utilities",
-	on_error = "crate::helpers::acknowledge_fail"
+    prefix_command,
+    slash_command,
+    category = "Utilities",
+    on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn ban(
-	ctx: Context<'_>,
-	#[description = "Banned user"] banned_user: serenity::Member,
-	#[description = "Ban reason"]
-	#[rest]
-	_reason: Option<String>,
+    ctx: Context<'_>,
+    #[description = "Banned user"] banned_user: serenity::Member,
+    #[description = "Ban reason"]
+    #[rest]
+    _reason: Option<String>,
 ) -> Result<(), Error> {
-	ctx.say(format!(
-		"Banned user {}  {}",
-		banned_user.user.name,
-		crate::helpers::custom_emoji_code(ctx, "ferrisBanne", '🔨')
-	))
-	.await?;
-	Ok(())
+    ctx.say(format!(
+        "Banned user {}  {}",
+        banned_user.user.name,
+        crate::helpers::custom_emoji_code(ctx, "ferrisBanne", '🔨')
+    ))
+    .await?;
+    Ok(())
 }
 
 /// Self-timeout yourself.
@@ -226,43 +229,43 @@ pub async fn ban(
 /// or in minutes.
 #[expect(clippy::doc_markdown, reason = "not markdown, shown to end user")]
 #[poise::command(
-	slash_command,
-	category = "Utilities",
-	on_error = "crate::helpers::acknowledge_fail"
+    slash_command,
+    category = "Utilities",
+    on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn selftimeout(
-	ctx: Context<'_>,
-	#[description = "Duration of self-timeout in hours"] duration_in_hours: Option<u64>,
-	#[description = "Duration of self-timeout in minutes"] duration_in_minutes: Option<u64>,
+    ctx: Context<'_>,
+    #[description = "Duration of self-timeout in hours"] duration_in_hours: Option<u64>,
+    #[description = "Duration of self-timeout in minutes"] duration_in_minutes: Option<u64>,
 ) -> Result<(), Error> {
-	let total_seconds = match (duration_in_hours, duration_in_minutes) {
-		(None, None) => 3600, // When nothing is specified, default to one hour.
-		(hours, minutes) => hours.unwrap_or(0) * 3600 + minutes.unwrap_or(0) * 60,
-	};
+    let total_seconds = match (duration_in_hours, duration_in_minutes) {
+        (None, None) => 3600, // When nothing is specified, default to one hour.
+        (hours, minutes) => hours.unwrap_or(0) * 3600 + minutes.unwrap_or(0) * 60,
+    };
 
-	let now = ctx.created_at().unix_timestamp();
+    let now = ctx.created_at().unix_timestamp();
 
-	let then = Timestamp::from_unix_timestamp(now + total_seconds as i64)?;
+    let then = Timestamp::from_unix_timestamp(now + total_seconds as i64)?;
 
-	let mut member = ctx
-		.author_member()
-		.await
-		.ok_or(anyhow!("failed to fetch member"))?
-		.into_owned();
+    let mut member = ctx
+        .author_member()
+        .await
+        .ok_or(anyhow!("failed to fetch member"))?
+        .into_owned();
 
-	member
-		.disable_communication_until_datetime(&ctx, then)
-		.await?;
+    member
+        .disable_communication_until_datetime(&ctx, then)
+        .await?;
 
-	ctx.say(format!(
-		"Self-timeout for {}. They'll be able to interact with the server again <t:{}:R>. \
+    ctx.say(format!(
+        "Self-timeout for {}. They'll be able to interact with the server again <t:{}:R>. \
 		If this was a mistake, please contact a moderator or try to enjoy the time off.",
-		ctx.author().name,
-		then.unix_timestamp()
-	))
-	.await?;
+        ctx.author().name,
+        then.unix_timestamp()
+    ))
+    .await?;
 
-	Ok(())
+    Ok(())
 }
 
 /// Marks the current thread as solved
@@ -272,13 +275,13 @@ pub async fn selftimeout(
 	discard_spare_arguments // to allow smooth integration in the closing message, e.g. "?solved, thank you"
 )]
 pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
-	let mut thread = ctx
-		.guild_channel()
-		.await
-		.filter(|channel| channel.kind == ChannelType::PublicThread)
-		.ok_or(anyhow!("not applicable here"))?;
+    let mut thread = ctx
+        .guild_channel()
+        .await
+        .filter(|channel| channel.kind == ChannelType::PublicThread)
+        .ok_or(anyhow!("not applicable here"))?;
 
-	let solved_tag = thread
+    let solved_tag = thread
 		.parent_id
 		.ok_or(anyhow!("thread lacks parent channel (¿dafuq?)"))? // to my knowledge threads can only ever exist within other channels
 		.to_channel(ctx)
@@ -290,19 +293,19 @@ pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
 		.find(|tag| tag.name == "Solved")
 		.ok_or(anyhow!("no 'Solved' tag available here"))?; // plausible scenario (e.g. wrong forum, or non-forum thread)
 
-	let tags_old = &thread.applied_tags;
+    let tags_old = &thread.applied_tags;
 
-	if tags_old.contains(&solved_tag.id) {
-		return Err(anyhow!("thread is already solved"));
-	}
+    if tags_old.contains(&solved_tag.id) {
+        return Err(anyhow!("thread is already solved"));
+    }
 
-	let tags_new = tags_old.iter().copied().chain(iter::once(solved_tag.id));
+    let tags_new = tags_old.iter().copied().chain(iter::once(solved_tag.id));
 
-	thread
-		.edit_thread(ctx, EditThread::new().applied_tags(tags_new))
-		.await?;
+    thread
+        .edit_thread(ctx, EditThread::new().applied_tags(tags_new))
+        .await?;
 
-	Ok(())
+    Ok(())
 }
 /// Edit a message by its ID
 ///
@@ -311,80 +314,131 @@ pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
 /// Replaces the content of the specified message with your next message.
 /// Only moderators can use this command.
 #[poise::command(
-	slash_command,
-	category = "Utilities",
-	check = "crate::checks::check_is_moderator",
-	on_error = "crate::helpers::acknowledge_fail"
+    slash_command,
+    category = "Utilities",
+    check = "crate::checks::check_is_moderator",
+    on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn edit(
-	ctx: Context<'_>,
-	#[description = "Link to the message to edit"] mut message: serenity::Message,
+    ctx: Context<'_>,
+    #[description = "Link to the message to edit"] mut message: serenity::Message,
 ) -> Result<(), Error> {
-	ctx.send(
-		poise::CreateReply::default()
-			.content("✅ Please send the new content for the message. I'll wait for 60 seconds.")
-			.ephemeral(true),
-	)
-	.await?;
+    ctx.send(
+        poise::CreateReply::default()
+            .content("✅ Please send the new content for the message. I'll wait for 60 seconds.")
+            .ephemeral(true),
+    )
+    .await?;
 
-	// Wait for the next message from the same user in the same channel
-	let author_id = ctx.author().id;
-	let channel_id = ctx.channel_id();
+    // Wait for the next message from the same user in the same channel
+    let author_id = ctx.author().id;
+    let channel_id = ctx.channel_id();
 
-	let new_content = {
-		let collector = serenity::MessageCollector::new(ctx.serenity_context())
-			.author_id(author_id)
-			.channel_id(channel_id)
-			.timeout(Duration::from_secs(60));
+    let new_content = {
+        let collector = serenity::MessageCollector::new(ctx.serenity_context())
+            .author_id(author_id)
+            .channel_id(channel_id)
+            .timeout(Duration::from_secs(60));
 
-		match collector.next().await {
-			Some(msg) if !msg.content.is_empty() => msg.content,
-			Some(_) => {
-				ctx.send(
-					poise::CreateReply::default()
-						.content("❌ Empty message received. Edit cancelled.")
-						.ephemeral(true),
-				)
-				.await?;
-				return Ok(());
-			}
-			None => {
-				ctx.send(
-					poise::CreateReply::default()
-						.content(
-							"⏰ Timeout: No message received within 60 seconds. Edit cancelled.",
-						)
-						.ephemeral(true),
-				)
-				.await?;
-				return Ok(());
-			}
-		}
-	};
+        match collector.next().await {
+            Some(msg) if !msg.content.is_empty() => msg.content,
+            Some(_) => {
+                ctx.send(
+                    poise::CreateReply::default()
+                        .content("❌ Empty message received. Edit cancelled.")
+                        .ephemeral(true),
+                )
+                .await?;
+                return Ok(());
+            }
+            None => {
+                ctx.send(
+                    poise::CreateReply::default()
+                        .content(
+                            "⏰ Timeout: No message received within 60 seconds. Edit cancelled.",
+                        )
+                        .ephemeral(true),
+                )
+                .await?;
+                return Ok(());
+            }
+        }
+    };
 
-	// Log the old message content before editing
-	if let Err(e) =
-		crate::helpers::send_audit_log(ctx, "Edit Command", ctx.author().id, &message.content).await
-	{
-		ctx.send(
-			poise::CreateReply::default()
-				.content(format!("❌ Failed to log audit information: {e}"))
-				.ephemeral(true),
-		)
-		.await?;
-		return Ok(());
-	}
+    // Log the old message content before editing
+    if let Err(e) =
+        crate::helpers::send_audit_log(ctx, "Edit Command", ctx.author().id, &message.content).await
+    {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(format!("❌ Failed to log audit information: {e}"))
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
 
-	message
-		.edit(&ctx, serenity::EditMessage::new().content(&new_content))
-		.await?;
+    message
+        .edit(&ctx, serenity::EditMessage::new().content(&new_content))
+        .await?;
 
-	ctx.send(
-		poise::CreateReply::default()
-			.content("✅ Message edited successfully!")
-			.ephemeral(true),
-	)
-	.await?;
+    ctx.send(
+        poise::CreateReply::default()
+            .content("✅ Message edited successfully!")
+            .ephemeral(true),
+    )
+    .await?;
 
-	Ok(())
+    Ok(())
+}
+
+#[poise::command(
+    slash_command,
+    prefix_command,
+    category = "Utilities",
+    on_error = "crate::helpers::acknowledge_fail"
+)]
+pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
+    let guild = ctx
+        .guild()
+        .ok_or(anyhow!("Failed to get guild information"))?
+        .clone();
+    let member_count = guild.member_count;
+    let online_member_count = guild
+        .members_with_status(serenity::OnlineStatus::Online)
+        .count();
+    let boost_count = guild.premium_subscription_count.unwrap_or_default();
+    let text_channel_count = guild
+        .channels
+        .iter()
+        .filter(|f| f.1.kind == ChannelType::Text)
+        .count();
+    let voice_channel_count = guild
+        .channels
+        .iter()
+        .filter(|f| f.1.kind == ChannelType::Voice)
+        .count();
+
+    info!("Got guild icon: {:?}", guild.icon_url());
+    let embed = CreateEmbed::new()
+        .title(&guild.name)
+        .thumbnail(guild.icon_url().unwrap_or_default())
+        .color(Color::ORANGE)
+        .fields([
+            ("Members", format!("{online_member_count}/{member_count}"), true),
+            ("Boost Count", format!("{boost_count}"), true),
+            ("Text Channels", format!("{text_channel_count}"), true),
+            ("Voice Channels", format!("{voice_channel_count}"), true),
+        ])
+        .description(
+            "The Rust Programming Language Community Server is all about learning and sharing Rust knowledge, and helping others.",
+        );
+    let reply = CreateReply {
+        embeds: vec![embed],
+
+        ..Default::default()
+    };
+    ctx.send(reply).await?;
+
+    Ok(())
 }

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -401,6 +401,7 @@ pub async fn edit(
     category = "Utilities",
     on_error = "crate::helpers::acknowledge_fail"
 )]
+/// Shows information about the server
 pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
     let guild = ctx
         .guild()
@@ -452,7 +453,11 @@ pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
     category = "Utilities",
     on_error = "crate::helpers::acknowledge_fail"
 )]
-pub async fn user(ctx: Context<'_>, user: Option<serenity::User>) -> Result<(), Error> {
+/// Shows information about a user
+pub async fn user(
+    ctx: Context<'_>,
+    #[description = "User to get information about"] user: Option<serenity::User>,
+) -> Result<(), Error> {
     let user = user.unwrap_or_else(|| ctx.author().clone());
     let uid = user.id.get();
     let name = user.display_name();

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -1,10 +1,10 @@
 use anyhow::{Error, anyhow};
 use itertools::Itertools;
 use poise::{
-    CreateReply,
-    serenity_prelude::{
-        self as serenity, ChannelType, Color, CreateEmbed, CreateEmbedFooter, EditThread, Timestamp,
-    },
+	CreateReply,
+	serenity_prelude::{
+		self as serenity, ChannelType, Color, CreateEmbed, CreateEmbedFooter, EditThread, Timestamp,
+	},
 };
 use rand::Rng;
 use std::iter;
@@ -16,145 +16,145 @@ use crate::types::Context;
 
 /// Evaluates Go code
 #[poise::command(
-    prefix_command,
-    slash_command,
-    category = "Utilities",
-    discard_spare_arguments
+	prefix_command,
+	slash_command,
+	category = "Utilities",
+	discard_spare_arguments
 )]
 pub async fn go(ctx: Context<'_>) -> Result<(), Error> {
-    if rand::rng().random_bool(0.01) {
-        ctx.say("Yes").await?;
-    } else {
-        ctx.say("No").await?;
-    }
-    Ok(())
+	if rand::rng().random_bool(0.01) {
+		ctx.say("Yes").await?;
+	} else {
+		ctx.say("No").await?;
+	}
+	Ok(())
 }
 
 /// Links to the bot GitHub repo
 #[poise::command(
-    prefix_command,
-    slash_command,
-    category = "Utilities",
-    discard_spare_arguments
+	prefix_command,
+	slash_command,
+	category = "Utilities",
+	discard_spare_arguments
 )]
 pub async fn source(ctx: Context<'_>) -> Result<(), Error> {
-    ctx.say("https://github.com/rust-community-discord/ferrisbot-for-discord")
-        .await?;
-    Ok(())
+	ctx.say("https://github.com/rust-community-discord/ferrisbot-for-discord")
+		.await?;
+	Ok(())
 }
 
 /// Show this menu
 #[poise::command(prefix_command, slash_command, category = "Utilities", track_edits)]
 pub async fn help(
-    ctx: Context<'_>,
-    #[description = "Specific command to show help about"]
-    #[autocomplete = "poise::builtins::autocomplete_command"]
-    command: Option<String>,
+	ctx: Context<'_>,
+	#[description = "Specific command to show help about"]
+	#[autocomplete = "poise::builtins::autocomplete_command"]
+	command: Option<String>,
 ) -> Result<(), Error> {
-    let extra_text_at_bottom = "\
+	let extra_text_at_bottom = "\
 You can still use all commands with `?`, even if it says `/` above.
 Type ?help command for more info on a command.
 You can edit your message to the bot and the bot will edit its response.";
 
-    poise::builtins::help(
-        ctx,
-        command.as_deref(),
-        poise::builtins::HelpConfiguration {
-            extra_text_at_bottom,
-            ephemeral: true,
-            ..Default::default()
-        },
-    )
-    .await?;
-    Ok(())
+	poise::builtins::help(
+		ctx,
+		command.as_deref(),
+		poise::builtins::HelpConfiguration {
+			extra_text_at_bottom,
+			ephemeral: true,
+			..Default::default()
+		},
+	)
+	.await?;
+	Ok(())
 }
 
 /// Register slash commands in this guild or globally
 #[poise::command(
-    prefix_command,
-    slash_command,
-    category = "Utilities",
-    hide_in_help,
-    check = "crate::checks::check_is_moderator"
+	prefix_command,
+	slash_command,
+	category = "Utilities",
+	hide_in_help,
+	check = "crate::checks::check_is_moderator"
 )]
 pub async fn register(ctx: Context<'_>) -> Result<(), Error> {
-    poise::builtins::register_application_commands_buttons(ctx).await?;
+	poise::builtins::register_application_commands_buttons(ctx).await?;
 
-    Ok(())
+	Ok(())
 }
 
 /// Tells you how long the bot has been up for
 #[poise::command(prefix_command, slash_command, category = "Utilities")]
 pub async fn uptime(ctx: Context<'_>) -> Result<(), Error> {
-    let uptime = ctx.data().bot_start_time.elapsed();
+	let uptime = ctx.data().bot_start_time.elapsed();
 
-    let div_mod = |a, b| (a / b, a % b);
+	let div_mod = |a, b| (a / b, a % b);
 
-    let seconds = uptime.as_secs();
-    let (minutes, seconds) = div_mod(seconds, 60);
-    let (hours, minutes) = div_mod(minutes, 60);
-    let (days, hours) = div_mod(hours, 24);
+	let seconds = uptime.as_secs();
+	let (minutes, seconds) = div_mod(seconds, 60);
+	let (hours, minutes) = div_mod(minutes, 60);
+	let (days, hours) = div_mod(hours, 24);
 
-    ctx.say(format!("Uptime: {days}d {hours}h {minutes}m {seconds}s"))
-        .await?;
+	ctx.say(format!("Uptime: {days}d {hours}h {minutes}m {seconds}s"))
+		.await?;
 
-    Ok(())
+	Ok(())
 }
 
 /// Use this joke command to have Conrad Ludgate tell you to get something
 ///
 /// Example: `/conradluget a better computer`
 #[poise::command(
-    prefix_command,
-    slash_command,
-    category = "Utilities",
-    track_edits,
-    hide_in_help
+	prefix_command,
+	slash_command,
+	category = "Utilities",
+	track_edits,
+	hide_in_help
 )]
 pub async fn conradluget(
-    ctx: Context<'_>,
-    #[description = "Get what?"]
-    #[rest]
-    text: String,
+	ctx: Context<'_>,
+	#[description = "Get what?"]
+	#[rest]
+	text: String,
 ) -> Result<(), Error> {
-    static BASE_IMAGE: LazyLock<image::DynamicImage> = LazyLock::new(|| {
-        image::ImageReader::with_format(
-            std::io::Cursor::new(&include_bytes!("../../assets/conrad.png")[..]),
-            image::ImageFormat::Png,
-        )
-        .decode()
-        .expect("failed to load image")
-    });
-    static FONT: LazyLock<ab_glyph::FontRef<'_>> = LazyLock::new(|| {
-        ab_glyph::FontRef::try_from_slice(include_bytes!("../../assets/OpenSans.ttf"))
-            .expect("failed to load font")
-    });
+	static BASE_IMAGE: LazyLock<image::DynamicImage> = LazyLock::new(|| {
+		image::ImageReader::with_format(
+			std::io::Cursor::new(&include_bytes!("../../assets/conrad.png")[..]),
+			image::ImageFormat::Png,
+		)
+		.decode()
+		.expect("failed to load image")
+	});
+	static FONT: LazyLock<ab_glyph::FontRef<'_>> = LazyLock::new(|| {
+		ab_glyph::FontRef::try_from_slice(include_bytes!("../../assets/OpenSans.ttf"))
+			.expect("failed to load font")
+	});
 
-    let text = format!("Get {text}");
-    let image = imageproc::drawing::draw_text(
-        &*BASE_IMAGE,
-        image::Rgba([201, 209, 217, 255]),
-        57,
-        286,
-        65.0,
-        &*FONT,
-        &text,
-    );
+	let text = format!("Get {text}");
+	let image = imageproc::drawing::draw_text(
+		&*BASE_IMAGE,
+		image::Rgba([201, 209, 217, 255]),
+		57,
+		286,
+		65.0,
+		&*FONT,
+		&text,
+	);
 
-    let mut img_bytes = Vec::with_capacity(200_000); // preallocate 200kB for the img
-    image::DynamicImage::ImageRgba8(image).write_to(
-        &mut std::io::Cursor::new(&mut img_bytes),
-        image::ImageFormat::Png,
-    )?;
+	let mut img_bytes = Vec::with_capacity(200_000); // preallocate 200kB for the img
+	image::DynamicImage::ImageRgba8(image).write_to(
+		&mut std::io::Cursor::new(&mut img_bytes),
+		image::ImageFormat::Png,
+	)?;
 
-    let filename = text + ".png";
+	let filename = text + ".png";
 
-    let attachment = serenity::CreateAttachment::bytes(img_bytes, filename);
+	let attachment = serenity::CreateAttachment::bytes(img_bytes, filename);
 
-    ctx.send(poise::CreateReply::default().attachment(attachment))
-        .await?;
+	ctx.send(poise::CreateReply::default().attachment(attachment))
+		.await?;
 
-    Ok(())
+	Ok(())
 }
 
 /// Deletes the bot's messages for cleanup
@@ -167,33 +167,33 @@ pub async fn conradluget(
 /// You can specify how many messages to look for. Only the 20 most recent messages within the
 /// channel from the last 24 hours can be deleted.
 #[poise::command(
-    prefix_command,
-    slash_command,
-    category = "Utilities",
-    on_error = "crate::helpers::acknowledge_fail"
+	prefix_command,
+	slash_command,
+	category = "Utilities",
+	on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn cleanup(
-    ctx: Context<'_>,
-    #[description = "Number of messages to delete"] num_messages: Option<usize>,
+	ctx: Context<'_>,
+	#[description = "Number of messages to delete"] num_messages: Option<usize>,
 ) -> Result<(), Error> {
-    let num_messages = num_messages.unwrap_or(1);
+	let num_messages = num_messages.unwrap_or(1);
 
-    let messages_to_delete = ctx
-        .channel_id()
-        .messages(&ctx, serenity::GetMessages::new().limit(20))
-        .await?
-        .into_iter()
-        .filter(|msg| {
-            (msg.author.id == ctx.data().application_id)
-                && (*ctx.created_at() - *msg.timestamp).num_hours() < 24
-        })
-        .take(num_messages);
+	let messages_to_delete = ctx
+		.channel_id()
+		.messages(&ctx, serenity::GetMessages::new().limit(20))
+		.await?
+		.into_iter()
+		.filter(|msg| {
+			(msg.author.id == ctx.data().application_id)
+				&& (*ctx.created_at() - *msg.timestamp).num_hours() < 24
+		})
+		.take(num_messages);
 
-    ctx.channel_id()
-        .delete_messages(&ctx, messages_to_delete)
-        .await?;
+	ctx.channel_id()
+		.delete_messages(&ctx, messages_to_delete)
+		.await?;
 
-    crate::helpers::acknowledge_success(ctx, "rustOk", '👌').await
+	crate::helpers::acknowledge_success(ctx, "rustOk", '👌').await
 }
 
 /// Bans another person
@@ -202,25 +202,25 @@ pub async fn cleanup(
 ///
 /// Bans another person
 #[poise::command(
-    prefix_command,
-    slash_command,
-    category = "Utilities",
-    on_error = "crate::helpers::acknowledge_fail"
+	prefix_command,
+	slash_command,
+	category = "Utilities",
+	on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn ban(
-    ctx: Context<'_>,
-    #[description = "Banned user"] banned_user: serenity::Member,
-    #[description = "Ban reason"]
-    #[rest]
-    _reason: Option<String>,
+	ctx: Context<'_>,
+	#[description = "Banned user"] banned_user: serenity::Member,
+	#[description = "Ban reason"]
+	#[rest]
+	_reason: Option<String>,
 ) -> Result<(), Error> {
-    ctx.say(format!(
-        "Banned user {}  {}",
-        banned_user.user.name,
-        crate::helpers::custom_emoji_code(ctx, "ferrisBanne", '🔨')
-    ))
-    .await?;
-    Ok(())
+	ctx.say(format!(
+		"Banned user {}  {}",
+		banned_user.user.name,
+		crate::helpers::custom_emoji_code(ctx, "ferrisBanne", '🔨')
+	))
+	.await?;
+	Ok(())
 }
 
 /// Self-timeout yourself.
@@ -232,43 +232,43 @@ pub async fn ban(
 /// or in minutes.
 #[expect(clippy::doc_markdown, reason = "not markdown, shown to end user")]
 #[poise::command(
-    slash_command,
-    category = "Utilities",
-    on_error = "crate::helpers::acknowledge_fail"
+	slash_command,
+	category = "Utilities",
+	on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn selftimeout(
-    ctx: Context<'_>,
-    #[description = "Duration of self-timeout in hours"] duration_in_hours: Option<u64>,
-    #[description = "Duration of self-timeout in minutes"] duration_in_minutes: Option<u64>,
+	ctx: Context<'_>,
+	#[description = "Duration of self-timeout in hours"] duration_in_hours: Option<u64>,
+	#[description = "Duration of self-timeout in minutes"] duration_in_minutes: Option<u64>,
 ) -> Result<(), Error> {
-    let total_seconds = match (duration_in_hours, duration_in_minutes) {
-        (None, None) => 3600, // When nothing is specified, default to one hour.
-        (hours, minutes) => hours.unwrap_or(0) * 3600 + minutes.unwrap_or(0) * 60,
-    };
+	let total_seconds = match (duration_in_hours, duration_in_minutes) {
+		(None, None) => 3600, // When nothing is specified, default to one hour.
+		(hours, minutes) => hours.unwrap_or(0) * 3600 + minutes.unwrap_or(0) * 60,
+	};
 
-    let now = ctx.created_at().unix_timestamp();
+	let now = ctx.created_at().unix_timestamp();
 
-    let then = Timestamp::from_unix_timestamp(now + total_seconds as i64)?;
+	let then = Timestamp::from_unix_timestamp(now + total_seconds as i64)?;
 
-    let mut member = ctx
-        .author_member()
-        .await
-        .ok_or(anyhow!("failed to fetch member"))?
-        .into_owned();
+	let mut member = ctx
+		.author_member()
+		.await
+		.ok_or(anyhow!("failed to fetch member"))?
+		.into_owned();
 
-    member
-        .disable_communication_until_datetime(&ctx, then)
-        .await?;
+	member
+		.disable_communication_until_datetime(&ctx, then)
+		.await?;
 
-    ctx.say(format!(
-        "Self-timeout for {}. They'll be able to interact with the server again <t:{}:R>. \
+	ctx.say(format!(
+		"Self-timeout for {}. They'll be able to interact with the server again <t:{}:R>. \
 		If this was a mistake, please contact a moderator or try to enjoy the time off.",
-        ctx.author().name,
-        then.unix_timestamp()
-    ))
-    .await?;
+		ctx.author().name,
+		then.unix_timestamp()
+	))
+	.await?;
 
-    Ok(())
+	Ok(())
 }
 
 /// Marks the current thread as solved
@@ -278,13 +278,13 @@ pub async fn selftimeout(
 	discard_spare_arguments // to allow smooth integration in the closing message, e.g. "?solved, thank you"
 )]
 pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
-    let mut thread = ctx
-        .guild_channel()
-        .await
-        .filter(|channel| channel.kind == ChannelType::PublicThread)
-        .ok_or(anyhow!("not applicable here"))?;
+	let mut thread = ctx
+		.guild_channel()
+		.await
+		.filter(|channel| channel.kind == ChannelType::PublicThread)
+		.ok_or(anyhow!("not applicable here"))?;
 
-    let solved_tag = thread
+	let solved_tag = thread
 		.parent_id
 		.ok_or(anyhow!("thread lacks parent channel (¿dafuq?)"))? // to my knowledge threads can only ever exist within other channels
 		.to_channel(ctx)
@@ -296,19 +296,19 @@ pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
 		.find(|tag| tag.name == "Solved")
 		.ok_or(anyhow!("no 'Solved' tag available here"))?; // plausible scenario (e.g. wrong forum, or non-forum thread)
 
-    let tags_old = &thread.applied_tags;
+	let tags_old = &thread.applied_tags;
 
-    if tags_old.contains(&solved_tag.id) {
-        return Err(anyhow!("thread is already solved"));
-    }
+	if tags_old.contains(&solved_tag.id) {
+		return Err(anyhow!("thread is already solved"));
+	}
 
-    let tags_new = tags_old.iter().copied().chain(iter::once(solved_tag.id));
+	let tags_new = tags_old.iter().copied().chain(iter::once(solved_tag.id));
 
-    thread
-        .edit_thread(ctx, EditThread::new().applied_tags(tags_new))
-        .await?;
+	thread
+		.edit_thread(ctx, EditThread::new().applied_tags(tags_new))
+		.await?;
 
-    Ok(())
+	Ok(())
 }
 /// Edit a message by its ID
 ///
@@ -317,114 +317,114 @@ pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
 /// Replaces the content of the specified message with your next message.
 /// Only moderators can use this command.
 #[poise::command(
-    slash_command,
-    category = "Utilities",
-    check = "crate::checks::check_is_moderator",
-    on_error = "crate::helpers::acknowledge_fail"
+	slash_command,
+	category = "Utilities",
+	check = "crate::checks::check_is_moderator",
+	on_error = "crate::helpers::acknowledge_fail"
 )]
 pub async fn edit(
-    ctx: Context<'_>,
-    #[description = "Link to the message to edit"] mut message: serenity::Message,
+	ctx: Context<'_>,
+	#[description = "Link to the message to edit"] mut message: serenity::Message,
 ) -> Result<(), Error> {
-    ctx.send(
-        poise::CreateReply::default()
-            .content("✅ Please send the new content for the message. I'll wait for 60 seconds.")
-            .ephemeral(true),
-    )
-    .await?;
+	ctx.send(
+		poise::CreateReply::default()
+			.content("✅ Please send the new content for the message. I'll wait for 60 seconds.")
+			.ephemeral(true),
+	)
+	.await?;
 
-    // Wait for the next message from the same user in the same channel
-    let author_id = ctx.author().id;
-    let channel_id = ctx.channel_id();
+	// Wait for the next message from the same user in the same channel
+	let author_id = ctx.author().id;
+	let channel_id = ctx.channel_id();
 
-    let new_content = {
-        let collector = serenity::MessageCollector::new(ctx.serenity_context())
-            .author_id(author_id)
-            .channel_id(channel_id)
-            .timeout(Duration::from_secs(60));
+	let new_content = {
+		let collector = serenity::MessageCollector::new(ctx.serenity_context())
+			.author_id(author_id)
+			.channel_id(channel_id)
+			.timeout(Duration::from_secs(60));
 
-        match collector.next().await {
-            Some(msg) if !msg.content.is_empty() => msg.content,
-            Some(_) => {
-                ctx.send(
-                    poise::CreateReply::default()
-                        .content("❌ Empty message received. Edit cancelled.")
-                        .ephemeral(true),
-                )
-                .await?;
-                return Ok(());
-            }
-            None => {
-                ctx.send(
-                    poise::CreateReply::default()
-                        .content(
-                            "⏰ Timeout: No message received within 60 seconds. Edit cancelled.",
-                        )
-                        .ephemeral(true),
-                )
-                .await?;
-                return Ok(());
-            }
-        }
-    };
+		match collector.next().await {
+			Some(msg) if !msg.content.is_empty() => msg.content,
+			Some(_) => {
+				ctx.send(
+					poise::CreateReply::default()
+						.content("❌ Empty message received. Edit cancelled.")
+						.ephemeral(true),
+				)
+				.await?;
+				return Ok(());
+			}
+			None => {
+				ctx.send(
+					poise::CreateReply::default()
+						.content(
+							"⏰ Timeout: No message received within 60 seconds. Edit cancelled.",
+						)
+						.ephemeral(true),
+				)
+				.await?;
+				return Ok(());
+			}
+		}
+	};
 
-    // Log the old message content before editing
-    if let Err(e) =
-        crate::helpers::send_audit_log(ctx, "Edit Command", ctx.author().id, &message.content).await
-    {
-        ctx.send(
-            poise::CreateReply::default()
-                .content(format!("❌ Failed to log audit information: {e}"))
-                .ephemeral(true),
-        )
-        .await?;
-        return Ok(());
-    }
+	// Log the old message content before editing
+	if let Err(e) =
+		crate::helpers::send_audit_log(ctx, "Edit Command", ctx.author().id, &message.content).await
+	{
+		ctx.send(
+			poise::CreateReply::default()
+				.content(format!("❌ Failed to log audit information: {e}"))
+				.ephemeral(true),
+		)
+		.await?;
+		return Ok(());
+	}
 
-    message
-        .edit(&ctx, serenity::EditMessage::new().content(&new_content))
-        .await?;
+	message
+		.edit(&ctx, serenity::EditMessage::new().content(&new_content))
+		.await?;
 
-    ctx.send(
-        poise::CreateReply::default()
-            .content("✅ Message edited successfully!")
-            .ephemeral(true),
-    )
-    .await?;
+	ctx.send(
+		poise::CreateReply::default()
+			.content("✅ Message edited successfully!")
+			.ephemeral(true),
+	)
+	.await?;
 
-    Ok(())
+	Ok(())
 }
 
 #[poise::command(
-    slash_command,
-    prefix_command,
-    category = "Utilities",
-    on_error = "crate::helpers::acknowledge_fail"
+	slash_command,
+	prefix_command,
+	category = "Utilities",
+	on_error = "crate::helpers::acknowledge_fail"
 )]
 /// Shows information about the server
 pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
-    let guild = ctx
-        .guild()
-        .ok_or(anyhow!("Failed to get guild information"))?
-        .clone();
-    let member_count = guild.member_count;
-    let online_member_count = guild
-        .members_with_status(serenity::OnlineStatus::Online)
-        .count();
-    let boost_count = guild.premium_subscription_count.unwrap_or_default();
-    let text_channel_count = guild
-        .channels
-        .iter()
-        .filter(|f| f.1.kind == ChannelType::Text)
-        .count();
-    let voice_channel_count = guild
-        .channels
-        .iter()
-        .filter(|f| f.1.kind == ChannelType::Voice)
-        .count();
+	let guild = ctx
+		.guild()
+		.ok_or(anyhow!("Failed to get guild information"))?
+		.clone();
+	let member_count = guild.member_count;
+	let online_member_count = guild
+		.members_with_status(serenity::OnlineStatus::Online)
+		.count();
+	let boost_count = guild.premium_subscription_count.unwrap_or_default();
+	let text_channel_count = guild
+		.channels
+		.iter()
+		.filter(|f| f.1.kind == ChannelType::Text)
+		.count();
+	let voice_channel_count = guild
+		.channels
+		.iter()
+		.filter(|f| f.1.kind == ChannelType::Voice)
+		.count();
 
-    info!("Got guild icon: {:?}", guild.icon_url());
-    let embed = CreateEmbed::new()
+	info!("Got guild icon: {:?}", guild.icon_url());
+	let embed = CreateEmbed::new()
         .title(&guild.name)
         .thumbnail(guild.icon_url().unwrap_or_default())
         .color(Color::ORANGE)
@@ -437,65 +437,65 @@ pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
         .description(
             "The Rust Programming Language Community Server is all about learning and sharing Rust knowledge, and helping others.",
         );
-    let reply = CreateReply {
-        embeds: vec![embed],
+	let reply = CreateReply {
+		embeds: vec![embed],
 
-        ..Default::default()
-    };
-    ctx.send(reply).await?;
+		..Default::default()
+	};
+	ctx.send(reply).await?;
 
-    Ok(())
+	Ok(())
 }
 
 #[poise::command(
-    slash_command,
-    prefix_command,
-    category = "Utilities",
-    on_error = "crate::helpers::acknowledge_fail"
+	slash_command,
+	prefix_command,
+	category = "Utilities",
+	on_error = "crate::helpers::acknowledge_fail"
 )]
 /// Shows information about a user
 pub async fn user(
-    ctx: Context<'_>,
-    #[description = "User to get information about"] user: Option<serenity::User>,
+	ctx: Context<'_>,
+	#[description = "User to get information about"] user: Option<serenity::User>,
 ) -> Result<(), Error> {
-    let user = user.unwrap_or_else(|| ctx.author().clone());
-    let uid = user.id.get();
-    let name = user.display_name();
-    let handle = &user.name;
-    let created_at = user.created_at();
-    let guild = ctx
-        .guild()
-        .ok_or(anyhow!("Failed to get guild information"))?
-        .clone();
-    let member = guild.member(ctx.http(), uid).await?;
-    let joined_at = member.joined_at.unwrap_or_default();
-    let roles = member.roles(ctx.cache()).unwrap_or_default();
-    let status = guild.presences.get(&user.id);
-    let status = match status {
-        Some(status) => status.status,
-        None => serenity::OnlineStatus::Offline,
-    };
+	let user = user.unwrap_or_else(|| ctx.author().clone());
+	let uid = user.id.get();
+	let name = user.display_name();
+	let handle = &user.name;
+	let created_at = user.created_at();
+	let guild = ctx
+		.guild()
+		.ok_or(anyhow!("Failed to get guild information"))?
+		.clone();
+	let member = guild.member(ctx.http(), uid).await?;
+	let joined_at = member.joined_at.unwrap_or_default();
+	let roles = member.roles(ctx.cache()).unwrap_or_default();
+	let status = guild.presences.get(&user.id);
+	let status = match status {
+		Some(status) => status.status,
+		None => serenity::OnlineStatus::Offline,
+	};
 
-    let thumbnail = user.avatar_url().unwrap_or_default();
-    let fields = [
-        ("Created At", format!("{created_at}"), true),
-        ("Joined At", format!("{joined_at}"), true),
-        ("Status", status.name().to_string(), true),
-    ];
-    let embed = CreateEmbed::new()
-        .title(format!("{name} ({handle})"))
-        .thumbnail(thumbnail)
-        .color(Color::ORANGE)
-        .description(format!("User ID: {uid}"))
-        .footer(CreateEmbedFooter::new(
-            roles.iter().map(|r| r.name.clone()).join(" | "),
-        ))
-        .fields(fields);
-    let reply = CreateReply {
-        embeds: vec![embed],
+	let thumbnail = user.avatar_url().unwrap_or_default();
+	let fields = [
+		("Created At", format!("{created_at}"), true),
+		("Joined At", format!("{joined_at}"), true),
+		("Status", status.name().to_string(), true),
+	];
+	let embed = CreateEmbed::new()
+		.title(format!("{name} ({handle})"))
+		.thumbnail(thumbnail)
+		.color(Color::ORANGE)
+		.description(format!("User ID: {uid}"))
+		.footer(CreateEmbedFooter::new(
+			roles.iter().map(|r| r.name.clone()).join(" | "),
+		))
+		.fields(fields);
+	let reply = CreateReply {
+		embeds: vec![embed],
 
-        ..Default::default()
-    };
-    ctx.send(reply).await?;
-    Ok(())
+		..Default::default()
+	};
+	ctx.send(reply).await?;
+	Ok(())
 }

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -470,17 +470,11 @@ pub async fn user(
 	let member = guild.member(ctx.http(), uid).await?;
 	let joined_at = member.joined_at.unwrap_or_default();
 	let roles = member.roles(ctx.cache()).unwrap_or_default();
-	let status = guild.presences.get(&user.id);
-	let status = match status {
-		Some(status) => status.status,
-		None => serenity::OnlineStatus::Offline,
-	};
 
 	let thumbnail = user.avatar_url().unwrap_or_default();
 	let fields = [
 		("Created At", format!("{created_at}"), true),
 		("Joined At", format!("{joined_at}"), true),
-		("Status", status.name().to_string(), true),
 	];
 	let embed = CreateEmbed::new()
 		.title(format!("{name} ({handle})"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ pub async fn serenity(
 
     // Don't include presence updates, as they consume a lot of memory and CPU.
     let intents = serenity::GatewayIntents::non_privileged()
+        | serenity::GatewayIntents::GUILD_PRESENCES
         | serenity::GatewayIntents::GUILD_MEMBERS
         | serenity::GatewayIntents::MESSAGE_CONTENT;
 
@@ -218,6 +219,7 @@ fn build_command_list(enable_database: bool) -> Vec<poise::Command<Data, Error>>
         commands::utilities::go(),
         commands::utilities::source(),
         commands::utilities::server(),
+        commands::utilities::user(),
         commands::utilities::help(),
         commands::utilities::register(),
         commands::utilities::uptime(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,249 +40,249 @@ pub mod types;
 pub struct SecretStore(pub HashMap<String, String>);
 
 impl SecretStore {
-    #[must_use]
-    pub fn get(&self, key: &str) -> Option<String> {
-        self.0.get(key).cloned()
-    }
+	#[must_use]
+	pub fn get(&self, key: &str) -> Option<String> {
+		self.0.get(key).cloned()
+	}
 
-    /// Gets a secret and parses it as a Discord ID (u64).
-    ///
-    /// # Errors
-    /// Returns an error if the key is missing or the value cannot be parsed as u64.
-    pub fn get_discord_id(&self, key: &str) -> Result<u64, Error> {
-        self.get(key)
-            .ok_or_else(|| anyhow!("Failed to get '{key}' from the secret store"))?
-            .parse::<u64>()
-            .map_err(|e| anyhow!("Failed to parse '{key}' as u64: {e}"))
-    }
+	/// Gets a secret and parses it as a Discord ID (u64).
+	///
+	/// # Errors
+	/// Returns an error if the key is missing or the value cannot be parsed as u64.
+	pub fn get_discord_id(&self, key: &str) -> Result<u64, Error> {
+		self.get(key)
+			.ok_or_else(|| anyhow!("Failed to get '{key}' from the secret store"))?
+			.parse::<u64>()
+			.map_err(|e| anyhow!("Failed to parse '{key}' as u64: {e}"))
+	}
 }
 
 pub struct ShuttleSerenity(pub serenity::Client);
 
 impl From<serenity::Client> for ShuttleSerenity {
-    fn from(value: serenity::Client) -> Self {
-        Self(value)
-    }
+	fn from(value: serenity::Client) -> Self {
+		Self(value)
+	}
 }
 
 pub async fn serenity(
-    secret_store: SecretStore,
-    database: Option<sqlx::SqlitePool>,
+	secret_store: SecretStore,
+	database: Option<sqlx::SqlitePool>,
 ) -> Result<ShuttleSerenity, Error> {
-    let token = secret_store
-        .get("DISCORD_TOKEN")
-        .expect("Couldn't find your DISCORD_TOKEN!");
+	let token = secret_store
+		.get("DISCORD_TOKEN")
+		.expect("Couldn't find your DISCORD_TOKEN!");
 
-    let enable_database = database.is_some();
-    let command_list = build_command_list(enable_database);
+	let enable_database = database.is_some();
+	let command_list = build_command_list(enable_database);
 
-    if enable_database {
-        info!("Database enabled - registering database-dependent commands (tags, highlights)");
-    } else {
-        info!("Database disabled - skipping database-dependent commands");
-    }
+	if enable_database {
+		info!("Database enabled - registering database-dependent commands (tags, highlights)");
+	} else {
+		info!("Database disabled - skipping database-dependent commands");
+	}
 
-    let framework = poise::Framework::builder()
-        .setup(move |ctx, ready, framework| {
-            Box::pin(async move {
-                let data = Data::new(&secret_store, database).await?;
+	let framework = poise::Framework::builder()
+		.setup(move |ctx, ready, framework| {
+			Box::pin(async move {
+				let data = Data::new(&secret_store, database).await?;
 
-                info!(
-                    "Registering {} commands...",
-                    framework.options().commands.len()
-                );
-                poise::builtins::register_in_guild(
-                    ctx,
-                    &framework.options().commands,
-                    data.discord_guild_id,
-                )
-                .await?;
+				info!(
+					"Registering {} commands...",
+					framework.options().commands.len()
+				);
+				poise::builtins::register_in_guild(
+					ctx,
+					&framework.options().commands,
+					data.discord_guild_id,
+				)
+				.await?;
 
-                debug!("Setting activity text");
-                ctx.set_activity(Some(serenity::ActivityData::listening("/help")));
+				debug!("Setting activity text");
+				ctx.set_activity(Some(serenity::ActivityData::listening("/help")));
 
-                load_or_create_modmail_message(ctx, &data).await?;
+				load_or_create_modmail_message(ctx, &data).await?;
 
-                info!("ferrisbot-for-discord logged in as {}", ready.user.name);
-                Ok(data)
-            })
-        })
-        .options(poise::FrameworkOptions {
-            commands: command_list,
-            prefix_options: poise::PrefixFrameworkOptions {
-                prefix: Some("?".into()),
-                additional_prefixes: vec![
-                    poise::Prefix::Literal("🦀 "),
-                    poise::Prefix::Literal("🦀"),
-                    poise::Prefix::Literal("<:ferris:358652670585733120> "),
-                    poise::Prefix::Literal("<:ferris:358652670585733120>"),
-                    poise::Prefix::Literal("<:ferrisballSweat:678714352450142239> "),
-                    poise::Prefix::Literal("<:ferrisballSweat:678714352450142239>"),
-                    poise::Prefix::Literal("<:ferrisCat:1183779700485664820> "),
-                    poise::Prefix::Literal("<:ferrisCat:1183779700485664820>"),
-                    poise::Prefix::Literal("<:ferrisOwO:579331467000283136> "),
-                    poise::Prefix::Literal("<:ferrisOwO:579331467000283136>"),
-                    poise::Prefix::Regex(
-                        "(yo |hey )?(crab|ferris|fewwis),? can you (please |pwease )?"
-                            .parse()
-                            .unwrap(),
-                    ),
-                ],
-                edit_tracker: Some(Arc::new(poise::EditTracker::for_timespan(
-                    Duration::from_secs(60 * 5), // 5 minutes
-                ))),
-                ..Default::default()
-            },
-            // The global error handler for all error cases that may occur
-            on_error: |error| {
-                Box::pin(async move {
-                    warn!("Encountered error: {:?}", error);
-                    if let poise::FrameworkError::ArgumentParse { error, ctx, .. } = &error {
-                        let response = if error.is::<poise::CodeBlockError>() {
-                            FAILED_CODEBLOCK.to_owned()
-                        } else if let Some(multiline_help) = &ctx.command().help_text {
-                            format!("**{error}**\n{multiline_help}")
-                        } else {
-                            error.to_string()
-                        };
+				info!("ferrisbot-for-discord logged in as {}", ready.user.name);
+				Ok(data)
+			})
+		})
+		.options(poise::FrameworkOptions {
+			commands: command_list,
+			prefix_options: poise::PrefixFrameworkOptions {
+				prefix: Some("?".into()),
+				additional_prefixes: vec![
+					poise::Prefix::Literal("🦀 "),
+					poise::Prefix::Literal("🦀"),
+					poise::Prefix::Literal("<:ferris:358652670585733120> "),
+					poise::Prefix::Literal("<:ferris:358652670585733120>"),
+					poise::Prefix::Literal("<:ferrisballSweat:678714352450142239> "),
+					poise::Prefix::Literal("<:ferrisballSweat:678714352450142239>"),
+					poise::Prefix::Literal("<:ferrisCat:1183779700485664820> "),
+					poise::Prefix::Literal("<:ferrisCat:1183779700485664820>"),
+					poise::Prefix::Literal("<:ferrisOwO:579331467000283136> "),
+					poise::Prefix::Literal("<:ferrisOwO:579331467000283136>"),
+					poise::Prefix::Regex(
+						"(yo |hey )?(crab|ferris|fewwis),? can you (please |pwease )?"
+							.parse()
+							.unwrap(),
+					),
+				],
+				edit_tracker: Some(Arc::new(poise::EditTracker::for_timespan(
+					Duration::from_secs(60 * 5), // 5 minutes
+				))),
+				..Default::default()
+			},
+			// The global error handler for all error cases that may occur
+			on_error: |error| {
+				Box::pin(async move {
+					warn!("Encountered error: {:?}", error);
+					if let poise::FrameworkError::ArgumentParse { error, ctx, .. } = &error {
+						let response = if error.is::<poise::CodeBlockError>() {
+							FAILED_CODEBLOCK.to_owned()
+						} else if let Some(multiline_help) = &ctx.command().help_text {
+							format!("**{error}**\n{multiline_help}")
+						} else {
+							error.to_string()
+						};
 
-                        try_say(ctx, response).await;
-                    } else if let poise::FrameworkError::Command { ctx, error, .. } = &error {
-                        if error.is::<poise::CodeBlockError>() {
-                            try_say(ctx, FAILED_CODEBLOCK).await;
-                        }
-                        try_say(ctx, error.to_string()).await;
-                    }
-                })
-            },
-            // This code is run before every command
-            pre_command: |ctx| {
-                Box::pin(async move {
-                    let channel_name = &ctx
-                        .channel_id()
-                        .name(&ctx)
-                        .await
-                        .unwrap_or_else(|_| "<unknown>".to_owned());
-                    let author = &ctx.author().name;
+						try_say(ctx, response).await;
+					} else if let poise::FrameworkError::Command { ctx, error, .. } = &error {
+						if error.is::<poise::CodeBlockError>() {
+							try_say(ctx, FAILED_CODEBLOCK).await;
+						}
+						try_say(ctx, error.to_string()).await;
+					}
+				})
+			},
+			// This code is run before every command
+			pre_command: |ctx| {
+				Box::pin(async move {
+					let channel_name = &ctx
+						.channel_id()
+						.name(&ctx)
+						.await
+						.unwrap_or_else(|_| "<unknown>".to_owned());
+					let author = &ctx.author().name;
 
-                    info!(
-                        "{} in {} used slash command '{}'",
-                        author,
-                        channel_name,
-                        &ctx.invoked_command_name()
-                    );
-                })
-            },
-            // This code is run after a command if it was successful (returned Ok)
-            post_command: |ctx| {
-                Box::pin(async move {
-                    info!("Executed command {}!", ctx.command().qualified_name);
-                })
-            },
-            // Every command invocation must pass this check to continue execution
-            command_check: Some(|_ctx| Box::pin(async move { Ok(true) })),
-            // Enforce command checks even for owners (enforced by default)
-            // Set to true to bypass checks, which is useful for testing
-            skip_checks_for_owners: false,
-            event_handler: |ctx, event, _framework, data| {
-                Box::pin(async move { event_handler(ctx, event, data).await })
-            },
-            // Disallow all mentions (except those to the replied user) by default
-            allowed_mentions: Some(serenity::CreateAllowedMentions::new().replied_user(true)),
-            ..Default::default()
-        })
-        .build();
+					info!(
+						"{} in {} used slash command '{}'",
+						author,
+						channel_name,
+						&ctx.invoked_command_name()
+					);
+				})
+			},
+			// This code is run after a command if it was successful (returned Ok)
+			post_command: |ctx| {
+				Box::pin(async move {
+					info!("Executed command {}!", ctx.command().qualified_name);
+				})
+			},
+			// Every command invocation must pass this check to continue execution
+			command_check: Some(|_ctx| Box::pin(async move { Ok(true) })),
+			// Enforce command checks even for owners (enforced by default)
+			// Set to true to bypass checks, which is useful for testing
+			skip_checks_for_owners: false,
+			event_handler: |ctx, event, _framework, data| {
+				Box::pin(async move { event_handler(ctx, event, data).await })
+			},
+			// Disallow all mentions (except those to the replied user) by default
+			allowed_mentions: Some(serenity::CreateAllowedMentions::new().replied_user(true)),
+			..Default::default()
+		})
+		.build();
 
-    // Don't include presence updates, as they consume a lot of memory and CPU.
-    let intents = serenity::GatewayIntents::non_privileged()
-        | serenity::GatewayIntents::GUILD_PRESENCES
-        | serenity::GatewayIntents::GUILD_MEMBERS
-        | serenity::GatewayIntents::MESSAGE_CONTENT;
+	// Don't include presence updates, as they consume a lot of memory and CPU.
+	let intents = serenity::GatewayIntents::non_privileged()
+		| serenity::GatewayIntents::GUILD_PRESENCES
+		| serenity::GatewayIntents::GUILD_MEMBERS
+		| serenity::GatewayIntents::MESSAGE_CONTENT;
 
-    let client = serenity::ClientBuilder::new(token, intents)
-        .framework(framework)
-        .await
-        .map_err(|e| anyhow!(e))?;
+	let client = serenity::ClientBuilder::new(token, intents)
+		.framework(framework)
+		.await
+		.map_err(|e| anyhow!(e))?;
 
-    Ok(client.into())
+	Ok(client.into())
 }
 
 fn build_command_list(enable_database: bool) -> Vec<poise::Command<Data, Error>> {
-    let mut command_list = vec![
-        commands::man::man(),
-        commands::crates::crate_(),
-        commands::crates::doc(),
-        commands::godbolt::godbolt(),
-        commands::godbolt::mca(),
-        commands::godbolt::llvmir(),
-        commands::godbolt::targets(),
-        commands::utilities::go(),
-        commands::utilities::source(),
-        commands::utilities::server(),
-        commands::utilities::user(),
-        commands::utilities::help(),
-        commands::utilities::register(),
-        commands::utilities::uptime(),
-        commands::utilities::conradluget(),
-        commands::utilities::cleanup(),
-        commands::utilities::ban(),
-        commands::utilities::selftimeout(),
-        commands::utilities::solved(),
-        commands::utilities::edit(),
-        commands::thread_pin::thread_pin(),
-        commands::modmail::modmail(),
-        commands::modmail::modmail_context_menu_for_message(),
-        commands::modmail::modmail_context_menu_for_user(),
-        commands::moving::move_messages_context_menu(),
-        commands::playground::play(),
-        commands::playground::playwarn(),
-        commands::playground::eval(),
-        commands::playground::miri(),
-        commands::playground::expand(),
-        commands::playground::clippy(),
-        commands::playground::fmt(),
-        commands::playground::microbench(),
-        commands::playground::procmacro(),
-    ];
-    if enable_database {
-        command_list.extend([
-            commands::highlight::highlight(),
-            commands::tags::tags(),
-            commands::tags::tag(),
-        ]);
-    }
-    command_list
+	let mut command_list = vec![
+		commands::man::man(),
+		commands::crates::crate_(),
+		commands::crates::doc(),
+		commands::godbolt::godbolt(),
+		commands::godbolt::mca(),
+		commands::godbolt::llvmir(),
+		commands::godbolt::targets(),
+		commands::utilities::go(),
+		commands::utilities::source(),
+		commands::utilities::server(),
+		commands::utilities::user(),
+		commands::utilities::help(),
+		commands::utilities::register(),
+		commands::utilities::uptime(),
+		commands::utilities::conradluget(),
+		commands::utilities::cleanup(),
+		commands::utilities::ban(),
+		commands::utilities::selftimeout(),
+		commands::utilities::solved(),
+		commands::utilities::edit(),
+		commands::thread_pin::thread_pin(),
+		commands::modmail::modmail(),
+		commands::modmail::modmail_context_menu_for_message(),
+		commands::modmail::modmail_context_menu_for_user(),
+		commands::moving::move_messages_context_menu(),
+		commands::playground::play(),
+		commands::playground::playwarn(),
+		commands::playground::eval(),
+		commands::playground::miri(),
+		commands::playground::expand(),
+		commands::playground::clippy(),
+		commands::playground::fmt(),
+		commands::playground::microbench(),
+		commands::playground::procmacro(),
+	];
+	if enable_database {
+		command_list.extend([
+			commands::highlight::highlight(),
+			commands::tags::tags(),
+			commands::tags::tag(),
+		]);
+	}
+	command_list
 }
 
 /// Attempts to send a message, logging any failures.
 /// This is useful for error handling paths where we don't want to fail the entire operation
 /// if we can't send an error message.
 async fn try_say(ctx: &poise::Context<'_, Data, Error>, message: impl Into<String>) {
-    let msg = message.into();
-    if let Err(e) = ctx.say(&msg).await {
-        warn!(
-            "Failed to send message '{}...': {}",
-            &msg[..msg.len().min(50)],
-            e
-        );
-    }
+	let msg = message.into();
+	if let Err(e) = ctx.say(&msg).await {
+		warn!(
+			"Failed to send message '{}...': {}",
+			&msg[..msg.len().min(50)],
+			e
+		);
+	}
 }
 
 async fn event_handler(
-    ctx: &serenity::Context,
-    event: &serenity::FullEvent,
-    data: &Data,
+	ctx: &serenity::Context,
+	event: &serenity::FullEvent,
+	data: &Data,
 ) -> Result<(), Error> {
-    debug!(
-        "Got an event in event handler: {:?}",
-        event.snake_case_name()
-    );
+	debug!(
+		"Got an event in event handler: {:?}",
+		event.snake_case_name()
+	);
 
-    match event {
-        serenity::FullEvent::GuildMemberAddition { new_member } => {
-            const RUSTIFICATION_DELAY: u64 = 30; // in minutes
+	match event {
+		serenity::FullEvent::GuildMemberAddition { new_member } => {
+			const RUSTIFICATION_DELAY: u64 = 30; // in minutes
 
-            tokio::time::sleep(Duration::from_secs(RUSTIFICATION_DELAY * 60)).await;
+			tokio::time::sleep(Duration::from_secs(RUSTIFICATION_DELAY * 60)).await;
 
 			// Ignore errors because the user may have left already
 			let _: Result<_, _> = ctx
@@ -344,72 +344,72 @@ async fn event_handler(
 									)),
 								)
 								.await;
-                        }
-                    })
-                    .buffer_unordered(8);
-                while let Some(()) = stream.next().await {}
-            }
-        }
-        serenity::FullEvent::InteractionCreate {
-            interaction: serenity::Interaction::Component(component),
-            ..
-        } if component.data.custom_id == "rplcs_create_new_modmail" => {
-            let message = "Created from modmail button";
-            create_modmail_thread(ctx, message, data, component.user.id).await?;
-        }
-        _ => {}
-    }
+						}
+					})
+					.buffer_unordered(8);
+				while let Some(()) = stream.next().await {}
+			}
+		}
+		serenity::FullEvent::InteractionCreate {
+			interaction: serenity::Interaction::Component(component),
+			..
+		} if component.data.custom_id == "rplcs_create_new_modmail" => {
+			let message = "Created from modmail button";
+			create_modmail_thread(ctx, message, data, component.user.id).await?;
+		}
+		_ => {}
+	}
 
-    Ok(())
+	Ok(())
 }
 
 async fn fetch_icon_paths() -> tokio::io::Result<Box<[PathBuf]>> {
-    let mut icon_paths = Vec::new();
-    let mut icon_path_iter = tokio::fs::read_dir("./assets/server-icons").await?;
-    while let Some(entry) = icon_path_iter.next_entry().await? {
-        let path = entry.path();
-        if path.is_file() {
-            icon_paths.push(path);
-        }
-    }
+	let mut icon_paths = Vec::new();
+	let mut icon_path_iter = tokio::fs::read_dir("./assets/server-icons").await?;
+	while let Some(entry) = icon_path_iter.next_entry().await? {
+		let path = entry.path();
+		if path.is_file() {
+			icon_paths.push(path);
+		}
+	}
 
-    Ok(icon_paths.into())
+	Ok(icon_paths.into())
 }
 
 async fn init_server_icon_changer(
-    ctx: impl serenity::CacheHttp,
-    guild_id: serenity::GuildId,
+	ctx: impl serenity::CacheHttp,
+	guild_id: serenity::GuildId,
 ) -> anyhow::Result<()> {
-    let icon_paths = fetch_icon_paths()
-        .await
-        .map_err(|e| anyhow!("Failed to read server-icons directory: {e}"))?;
+	let icon_paths = fetch_icon_paths()
+		.await
+		.map_err(|e| anyhow!("Failed to read server-icons directory: {e}"))?;
 
-    if icon_paths.is_empty() {
-        warn!("No server icons found in assets/server-icons; skipping icon rotation");
-        return Ok(());
-    }
+	if icon_paths.is_empty() {
+		warn!("No server icons found in assets/server-icons; skipping icon rotation");
+		return Ok(());
+	}
 
-    loop {
-        // Attempt to find all images and select one at random
-        let icon = icon_paths.iter().choose(&mut rand::rng());
-        if let Some(icon_path) = icon {
-            info!("Changing server icon to {:?}", icon_path);
+	loop {
+		// Attempt to find all images and select one at random
+		let icon = icon_paths.iter().choose(&mut rand::rng());
+		if let Some(icon_path) = icon {
+			info!("Changing server icon to {:?}", icon_path);
 
-            // Attempt to change the server icon
-            let icon_change_result = async {
-                let icon = serenity::CreateAttachment::path(icon_path).await?;
-                let edit_guild = serenity::EditGuild::new().icon(Some(&icon));
-                guild_id.edit(&ctx, edit_guild).await
-            }
-            .await;
+			// Attempt to change the server icon
+			let icon_change_result = async {
+				let icon = serenity::CreateAttachment::path(icon_path).await?;
+				let edit_guild = serenity::EditGuild::new().icon(Some(&icon));
+				guild_id.edit(&ctx, edit_guild).await
+			}
+			.await;
 
-            if let Err(e) = icon_change_result {
-                warn!("Failed to change server icon: {}", e);
-            }
-        }
+			if let Err(e) = icon_change_result {
+				warn!("Failed to change server icon: {}", e);
+			}
+		}
 
-        // Sleep for between 24 and 48 hours
-        let sleep_duration = rand::rng().random_range((60 * 60 * 24)..(60 * 60 * 48));
-        tokio::time::sleep(Duration::from_secs(sleep_duration)).await;
-    }
+		// Sleep for between 24 and 48 hours
+		let sleep_duration = rand::rng().random_range((60 * 60 * 24)..(60 * 60 * 48));
+		tokio::time::sleep(Duration::from_secs(sleep_duration)).await;
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,246 +40,247 @@ pub mod types;
 pub struct SecretStore(pub HashMap<String, String>);
 
 impl SecretStore {
-	#[must_use]
-	pub fn get(&self, key: &str) -> Option<String> {
-		self.0.get(key).cloned()
-	}
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<String> {
+        self.0.get(key).cloned()
+    }
 
-	/// Gets a secret and parses it as a Discord ID (u64).
-	///
-	/// # Errors
-	/// Returns an error if the key is missing or the value cannot be parsed as u64.
-	pub fn get_discord_id(&self, key: &str) -> Result<u64, Error> {
-		self.get(key)
-			.ok_or_else(|| anyhow!("Failed to get '{key}' from the secret store"))?
-			.parse::<u64>()
-			.map_err(|e| anyhow!("Failed to parse '{key}' as u64: {e}"))
-	}
+    /// Gets a secret and parses it as a Discord ID (u64).
+    ///
+    /// # Errors
+    /// Returns an error if the key is missing or the value cannot be parsed as u64.
+    pub fn get_discord_id(&self, key: &str) -> Result<u64, Error> {
+        self.get(key)
+            .ok_or_else(|| anyhow!("Failed to get '{key}' from the secret store"))?
+            .parse::<u64>()
+            .map_err(|e| anyhow!("Failed to parse '{key}' as u64: {e}"))
+    }
 }
 
 pub struct ShuttleSerenity(pub serenity::Client);
 
 impl From<serenity::Client> for ShuttleSerenity {
-	fn from(value: serenity::Client) -> Self {
-		Self(value)
-	}
+    fn from(value: serenity::Client) -> Self {
+        Self(value)
+    }
 }
 
 pub async fn serenity(
-	secret_store: SecretStore,
-	database: Option<sqlx::SqlitePool>,
+    secret_store: SecretStore,
+    database: Option<sqlx::SqlitePool>,
 ) -> Result<ShuttleSerenity, Error> {
-	let token = secret_store
-		.get("DISCORD_TOKEN")
-		.expect("Couldn't find your DISCORD_TOKEN!");
+    let token = secret_store
+        .get("DISCORD_TOKEN")
+        .expect("Couldn't find your DISCORD_TOKEN!");
 
-	let enable_database = database.is_some();
-	let command_list = build_command_list(enable_database);
+    let enable_database = database.is_some();
+    let command_list = build_command_list(enable_database);
 
-	if enable_database {
-		info!("Database enabled - registering database-dependent commands (tags, highlights)");
-	} else {
-		info!("Database disabled - skipping database-dependent commands");
-	}
+    if enable_database {
+        info!("Database enabled - registering database-dependent commands (tags, highlights)");
+    } else {
+        info!("Database disabled - skipping database-dependent commands");
+    }
 
-	let framework = poise::Framework::builder()
-		.setup(move |ctx, ready, framework| {
-			Box::pin(async move {
-				let data = Data::new(&secret_store, database).await?;
+    let framework = poise::Framework::builder()
+        .setup(move |ctx, ready, framework| {
+            Box::pin(async move {
+                let data = Data::new(&secret_store, database).await?;
 
-				info!(
-					"Registering {} commands...",
-					framework.options().commands.len()
-				);
-				poise::builtins::register_in_guild(
-					ctx,
-					&framework.options().commands,
-					data.discord_guild_id,
-				)
-				.await?;
+                info!(
+                    "Registering {} commands...",
+                    framework.options().commands.len()
+                );
+                poise::builtins::register_in_guild(
+                    ctx,
+                    &framework.options().commands,
+                    data.discord_guild_id,
+                )
+                .await?;
 
-				debug!("Setting activity text");
-				ctx.set_activity(Some(serenity::ActivityData::listening("/help")));
+                debug!("Setting activity text");
+                ctx.set_activity(Some(serenity::ActivityData::listening("/help")));
 
-				load_or_create_modmail_message(ctx, &data).await?;
+                load_or_create_modmail_message(ctx, &data).await?;
 
-				info!("ferrisbot-for-discord logged in as {}", ready.user.name);
-				Ok(data)
-			})
-		})
-		.options(poise::FrameworkOptions {
-			commands: command_list,
-			prefix_options: poise::PrefixFrameworkOptions {
-				prefix: Some("?".into()),
-				additional_prefixes: vec![
-					poise::Prefix::Literal("🦀 "),
-					poise::Prefix::Literal("🦀"),
-					poise::Prefix::Literal("<:ferris:358652670585733120> "),
-					poise::Prefix::Literal("<:ferris:358652670585733120>"),
-					poise::Prefix::Literal("<:ferrisballSweat:678714352450142239> "),
-					poise::Prefix::Literal("<:ferrisballSweat:678714352450142239>"),
-					poise::Prefix::Literal("<:ferrisCat:1183779700485664820> "),
-					poise::Prefix::Literal("<:ferrisCat:1183779700485664820>"),
-					poise::Prefix::Literal("<:ferrisOwO:579331467000283136> "),
-					poise::Prefix::Literal("<:ferrisOwO:579331467000283136>"),
-					poise::Prefix::Regex(
-						"(yo |hey )?(crab|ferris|fewwis),? can you (please |pwease )?"
-							.parse()
-							.unwrap(),
-					),
-				],
-				edit_tracker: Some(Arc::new(poise::EditTracker::for_timespan(
-					Duration::from_secs(60 * 5), // 5 minutes
-				))),
-				..Default::default()
-			},
-			// The global error handler for all error cases that may occur
-			on_error: |error| {
-				Box::pin(async move {
-					warn!("Encountered error: {:?}", error);
-					if let poise::FrameworkError::ArgumentParse { error, ctx, .. } = &error {
-						let response = if error.is::<poise::CodeBlockError>() {
-							FAILED_CODEBLOCK.to_owned()
-						} else if let Some(multiline_help) = &ctx.command().help_text {
-							format!("**{error}**\n{multiline_help}")
-						} else {
-							error.to_string()
-						};
+                info!("ferrisbot-for-discord logged in as {}", ready.user.name);
+                Ok(data)
+            })
+        })
+        .options(poise::FrameworkOptions {
+            commands: command_list,
+            prefix_options: poise::PrefixFrameworkOptions {
+                prefix: Some("?".into()),
+                additional_prefixes: vec![
+                    poise::Prefix::Literal("🦀 "),
+                    poise::Prefix::Literal("🦀"),
+                    poise::Prefix::Literal("<:ferris:358652670585733120> "),
+                    poise::Prefix::Literal("<:ferris:358652670585733120>"),
+                    poise::Prefix::Literal("<:ferrisballSweat:678714352450142239> "),
+                    poise::Prefix::Literal("<:ferrisballSweat:678714352450142239>"),
+                    poise::Prefix::Literal("<:ferrisCat:1183779700485664820> "),
+                    poise::Prefix::Literal("<:ferrisCat:1183779700485664820>"),
+                    poise::Prefix::Literal("<:ferrisOwO:579331467000283136> "),
+                    poise::Prefix::Literal("<:ferrisOwO:579331467000283136>"),
+                    poise::Prefix::Regex(
+                        "(yo |hey )?(crab|ferris|fewwis),? can you (please |pwease )?"
+                            .parse()
+                            .unwrap(),
+                    ),
+                ],
+                edit_tracker: Some(Arc::new(poise::EditTracker::for_timespan(
+                    Duration::from_secs(60 * 5), // 5 minutes
+                ))),
+                ..Default::default()
+            },
+            // The global error handler for all error cases that may occur
+            on_error: |error| {
+                Box::pin(async move {
+                    warn!("Encountered error: {:?}", error);
+                    if let poise::FrameworkError::ArgumentParse { error, ctx, .. } = &error {
+                        let response = if error.is::<poise::CodeBlockError>() {
+                            FAILED_CODEBLOCK.to_owned()
+                        } else if let Some(multiline_help) = &ctx.command().help_text {
+                            format!("**{error}**\n{multiline_help}")
+                        } else {
+                            error.to_string()
+                        };
 
-						try_say(ctx, response).await;
-					} else if let poise::FrameworkError::Command { ctx, error, .. } = &error {
-						if error.is::<poise::CodeBlockError>() {
-							try_say(ctx, FAILED_CODEBLOCK).await;
-						}
-						try_say(ctx, error.to_string()).await;
-					}
-				})
-			},
-			// This code is run before every command
-			pre_command: |ctx| {
-				Box::pin(async move {
-					let channel_name = &ctx
-						.channel_id()
-						.name(&ctx)
-						.await
-						.unwrap_or_else(|_| "<unknown>".to_owned());
-					let author = &ctx.author().name;
+                        try_say(ctx, response).await;
+                    } else if let poise::FrameworkError::Command { ctx, error, .. } = &error {
+                        if error.is::<poise::CodeBlockError>() {
+                            try_say(ctx, FAILED_CODEBLOCK).await;
+                        }
+                        try_say(ctx, error.to_string()).await;
+                    }
+                })
+            },
+            // This code is run before every command
+            pre_command: |ctx| {
+                Box::pin(async move {
+                    let channel_name = &ctx
+                        .channel_id()
+                        .name(&ctx)
+                        .await
+                        .unwrap_or_else(|_| "<unknown>".to_owned());
+                    let author = &ctx.author().name;
 
-					info!(
-						"{} in {} used slash command '{}'",
-						author,
-						channel_name,
-						&ctx.invoked_command_name()
-					);
-				})
-			},
-			// This code is run after a command if it was successful (returned Ok)
-			post_command: |ctx| {
-				Box::pin(async move {
-					info!("Executed command {}!", ctx.command().qualified_name);
-				})
-			},
-			// Every command invocation must pass this check to continue execution
-			command_check: Some(|_ctx| Box::pin(async move { Ok(true) })),
-			// Enforce command checks even for owners (enforced by default)
-			// Set to true to bypass checks, which is useful for testing
-			skip_checks_for_owners: false,
-			event_handler: |ctx, event, _framework, data| {
-				Box::pin(async move { event_handler(ctx, event, data).await })
-			},
-			// Disallow all mentions (except those to the replied user) by default
-			allowed_mentions: Some(serenity::CreateAllowedMentions::new().replied_user(true)),
-			..Default::default()
-		})
-		.build();
+                    info!(
+                        "{} in {} used slash command '{}'",
+                        author,
+                        channel_name,
+                        &ctx.invoked_command_name()
+                    );
+                })
+            },
+            // This code is run after a command if it was successful (returned Ok)
+            post_command: |ctx| {
+                Box::pin(async move {
+                    info!("Executed command {}!", ctx.command().qualified_name);
+                })
+            },
+            // Every command invocation must pass this check to continue execution
+            command_check: Some(|_ctx| Box::pin(async move { Ok(true) })),
+            // Enforce command checks even for owners (enforced by default)
+            // Set to true to bypass checks, which is useful for testing
+            skip_checks_for_owners: false,
+            event_handler: |ctx, event, _framework, data| {
+                Box::pin(async move { event_handler(ctx, event, data).await })
+            },
+            // Disallow all mentions (except those to the replied user) by default
+            allowed_mentions: Some(serenity::CreateAllowedMentions::new().replied_user(true)),
+            ..Default::default()
+        })
+        .build();
 
-	// Don't include presence updates, as they consume a lot of memory and CPU.
-	let intents = serenity::GatewayIntents::non_privileged()
-		| serenity::GatewayIntents::GUILD_MEMBERS
-		| serenity::GatewayIntents::MESSAGE_CONTENT;
+    // Don't include presence updates, as they consume a lot of memory and CPU.
+    let intents = serenity::GatewayIntents::non_privileged()
+        | serenity::GatewayIntents::GUILD_MEMBERS
+        | serenity::GatewayIntents::MESSAGE_CONTENT;
 
-	let client = serenity::ClientBuilder::new(token, intents)
-		.framework(framework)
-		.await
-		.map_err(|e| anyhow!(e))?;
+    let client = serenity::ClientBuilder::new(token, intents)
+        .framework(framework)
+        .await
+        .map_err(|e| anyhow!(e))?;
 
-	Ok(client.into())
+    Ok(client.into())
 }
 
 fn build_command_list(enable_database: bool) -> Vec<poise::Command<Data, Error>> {
-	let mut command_list = vec![
-		commands::man::man(),
-		commands::crates::crate_(),
-		commands::crates::doc(),
-		commands::godbolt::godbolt(),
-		commands::godbolt::mca(),
-		commands::godbolt::llvmir(),
-		commands::godbolt::targets(),
-		commands::utilities::go(),
-		commands::utilities::source(),
-		commands::utilities::help(),
-		commands::utilities::register(),
-		commands::utilities::uptime(),
-		commands::utilities::conradluget(),
-		commands::utilities::cleanup(),
-		commands::utilities::ban(),
-		commands::utilities::selftimeout(),
-		commands::utilities::solved(),
-		commands::utilities::edit(),
-		commands::thread_pin::thread_pin(),
-		commands::modmail::modmail(),
-		commands::modmail::modmail_context_menu_for_message(),
-		commands::modmail::modmail_context_menu_for_user(),
-		commands::moving::move_messages_context_menu(),
-		commands::playground::play(),
-		commands::playground::playwarn(),
-		commands::playground::eval(),
-		commands::playground::miri(),
-		commands::playground::expand(),
-		commands::playground::clippy(),
-		commands::playground::fmt(),
-		commands::playground::microbench(),
-		commands::playground::procmacro(),
-	];
-	if enable_database {
-		command_list.extend([
-			commands::highlight::highlight(),
-			commands::tags::tags(),
-			commands::tags::tag(),
-		]);
-	}
-	command_list
+    let mut command_list = vec![
+        commands::man::man(),
+        commands::crates::crate_(),
+        commands::crates::doc(),
+        commands::godbolt::godbolt(),
+        commands::godbolt::mca(),
+        commands::godbolt::llvmir(),
+        commands::godbolt::targets(),
+        commands::utilities::go(),
+        commands::utilities::source(),
+        commands::utilities::server(),
+        commands::utilities::help(),
+        commands::utilities::register(),
+        commands::utilities::uptime(),
+        commands::utilities::conradluget(),
+        commands::utilities::cleanup(),
+        commands::utilities::ban(),
+        commands::utilities::selftimeout(),
+        commands::utilities::solved(),
+        commands::utilities::edit(),
+        commands::thread_pin::thread_pin(),
+        commands::modmail::modmail(),
+        commands::modmail::modmail_context_menu_for_message(),
+        commands::modmail::modmail_context_menu_for_user(),
+        commands::moving::move_messages_context_menu(),
+        commands::playground::play(),
+        commands::playground::playwarn(),
+        commands::playground::eval(),
+        commands::playground::miri(),
+        commands::playground::expand(),
+        commands::playground::clippy(),
+        commands::playground::fmt(),
+        commands::playground::microbench(),
+        commands::playground::procmacro(),
+    ];
+    if enable_database {
+        command_list.extend([
+            commands::highlight::highlight(),
+            commands::tags::tags(),
+            commands::tags::tag(),
+        ]);
+    }
+    command_list
 }
 
 /// Attempts to send a message, logging any failures.
 /// This is useful for error handling paths where we don't want to fail the entire operation
 /// if we can't send an error message.
 async fn try_say(ctx: &poise::Context<'_, Data, Error>, message: impl Into<String>) {
-	let msg = message.into();
-	if let Err(e) = ctx.say(&msg).await {
-		warn!(
-			"Failed to send message '{}...': {}",
-			&msg[..msg.len().min(50)],
-			e
-		);
-	}
+    let msg = message.into();
+    if let Err(e) = ctx.say(&msg).await {
+        warn!(
+            "Failed to send message '{}...': {}",
+            &msg[..msg.len().min(50)],
+            e
+        );
+    }
 }
 
 async fn event_handler(
-	ctx: &serenity::Context,
-	event: &serenity::FullEvent,
-	data: &Data,
+    ctx: &serenity::Context,
+    event: &serenity::FullEvent,
+    data: &Data,
 ) -> Result<(), Error> {
-	debug!(
-		"Got an event in event handler: {:?}",
-		event.snake_case_name()
-	);
+    debug!(
+        "Got an event in event handler: {:?}",
+        event.snake_case_name()
+    );
 
-	match event {
-		serenity::FullEvent::GuildMemberAddition { new_member } => {
-			const RUSTIFICATION_DELAY: u64 = 30; // in minutes
+    match event {
+        serenity::FullEvent::GuildMemberAddition { new_member } => {
+            const RUSTIFICATION_DELAY: u64 = 30; // in minutes
 
-			tokio::time::sleep(Duration::from_secs(RUSTIFICATION_DELAY * 60)).await;
+            tokio::time::sleep(Duration::from_secs(RUSTIFICATION_DELAY * 60)).await;
 
 			// Ignore errors because the user may have left already
 			let _: Result<_, _> = ctx
@@ -341,72 +342,72 @@ async fn event_handler(
 									)),
 								)
 								.await;
-						}
-					})
-					.buffer_unordered(8);
-				while let Some(()) = stream.next().await {}
-			}
-		}
-		serenity::FullEvent::InteractionCreate {
-			interaction: serenity::Interaction::Component(component),
-			..
-		} if component.data.custom_id == "rplcs_create_new_modmail" => {
-			let message = "Created from modmail button";
-			create_modmail_thread(ctx, message, data, component.user.id).await?;
-		}
-		_ => {}
-	}
+                        }
+                    })
+                    .buffer_unordered(8);
+                while let Some(()) = stream.next().await {}
+            }
+        }
+        serenity::FullEvent::InteractionCreate {
+            interaction: serenity::Interaction::Component(component),
+            ..
+        } if component.data.custom_id == "rplcs_create_new_modmail" => {
+            let message = "Created from modmail button";
+            create_modmail_thread(ctx, message, data, component.user.id).await?;
+        }
+        _ => {}
+    }
 
-	Ok(())
+    Ok(())
 }
 
 async fn fetch_icon_paths() -> tokio::io::Result<Box<[PathBuf]>> {
-	let mut icon_paths = Vec::new();
-	let mut icon_path_iter = tokio::fs::read_dir("./assets/server-icons").await?;
-	while let Some(entry) = icon_path_iter.next_entry().await? {
-		let path = entry.path();
-		if path.is_file() {
-			icon_paths.push(path);
-		}
-	}
+    let mut icon_paths = Vec::new();
+    let mut icon_path_iter = tokio::fs::read_dir("./assets/server-icons").await?;
+    while let Some(entry) = icon_path_iter.next_entry().await? {
+        let path = entry.path();
+        if path.is_file() {
+            icon_paths.push(path);
+        }
+    }
 
-	Ok(icon_paths.into())
+    Ok(icon_paths.into())
 }
 
 async fn init_server_icon_changer(
-	ctx: impl serenity::CacheHttp,
-	guild_id: serenity::GuildId,
+    ctx: impl serenity::CacheHttp,
+    guild_id: serenity::GuildId,
 ) -> anyhow::Result<()> {
-	let icon_paths = fetch_icon_paths()
-		.await
-		.map_err(|e| anyhow!("Failed to read server-icons directory: {e}"))?;
+    let icon_paths = fetch_icon_paths()
+        .await
+        .map_err(|e| anyhow!("Failed to read server-icons directory: {e}"))?;
 
-	if icon_paths.is_empty() {
-		warn!("No server icons found in assets/server-icons; skipping icon rotation");
-		return Ok(());
-	}
+    if icon_paths.is_empty() {
+        warn!("No server icons found in assets/server-icons; skipping icon rotation");
+        return Ok(());
+    }
 
-	loop {
-		// Attempt to find all images and select one at random
-		let icon = icon_paths.iter().choose(&mut rand::rng());
-		if let Some(icon_path) = icon {
-			info!("Changing server icon to {:?}", icon_path);
+    loop {
+        // Attempt to find all images and select one at random
+        let icon = icon_paths.iter().choose(&mut rand::rng());
+        if let Some(icon_path) = icon {
+            info!("Changing server icon to {:?}", icon_path);
 
-			// Attempt to change the server icon
-			let icon_change_result = async {
-				let icon = serenity::CreateAttachment::path(icon_path).await?;
-				let edit_guild = serenity::EditGuild::new().icon(Some(&icon));
-				guild_id.edit(&ctx, edit_guild).await
-			}
-			.await;
+            // Attempt to change the server icon
+            let icon_change_result = async {
+                let icon = serenity::CreateAttachment::path(icon_path).await?;
+                let edit_guild = serenity::EditGuild::new().icon(Some(&icon));
+                guild_id.edit(&ctx, edit_guild).await
+            }
+            .await;
 
-			if let Err(e) = icon_change_result {
-				warn!("Failed to change server icon: {}", e);
-			}
-		}
+            if let Err(e) = icon_change_result {
+                warn!("Failed to change server icon: {}", e);
+            }
+        }
 
-		// Sleep for between 24 and 48 hours
-		let sleep_duration = rand::rng().random_range((60 * 60 * 24)..(60 * 60 * 48));
-		tokio::time::sleep(Duration::from_secs(sleep_duration)).await;
-	}
+        // Sleep for between 24 and 48 hours
+        let sleep_duration = rand::rng().random_range((60 * 60 * 24)..(60 * 60 * 48));
+        tokio::time::sleep(Duration::from_secs(sleep_duration)).await;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,6 @@ pub async fn serenity(
 
 	// Don't include presence updates, as they consume a lot of memory and CPU.
 	let intents = serenity::GatewayIntents::non_privileged()
-		| serenity::GatewayIntents::GUILD_PRESENCES
 		| serenity::GatewayIntents::GUILD_MEMBERS
 		| serenity::GatewayIntents::MESSAGE_CONTENT;
 


### PR DESCRIPTION
Closes #52 

Caveat: I had to enable the `GUILD_PRESENCE` intent to have the user presence info in the `?user` command. The code noted that `GUILD_PRESENCE` intent requires a lot of CPU usage. If that is undesirable, i'd be happy to remove it.