### PR TITLE
commands/modmail: add new consultant role to modmails

### DIFF
--- a/config/ferris.secrets.template.toml
+++ b/config/ferris.secrets.template.toml
@@ -11,6 +11,9 @@ APPLICATION_ID = ""
 # ID of the Moderator role. Potentially used someday for `?cleanup` command
 MOD_ROLE_ID = ""
 
+# ID of the consultant role, which is CCed in modmails.
+MOD_CONSULTANT_ROLE_ID = ""
+
 # ID of the Rustacean role. Used for `?rustify` command
 RUSTACEAN_ROLE_ID = ""
 

--- a/src/commands/modmail.rs
+++ b/src/commands/modmail.rs
@@ -193,8 +193,9 @@ pub async fn create_modmail_thread(
 		.await?;
 
 	let thread_message_content = format!(
-		"Hey {}, {} needs help with the following:\n> {}",
+		"Hey {} (cc: {}), {} needs help with the following:\n> {}",
 		data.mod_role_id.mention(),
+		data.mod_consultant_role_id.mention(),
 		user_id.mention(),
 		user_message.into()
 	);
@@ -207,7 +208,7 @@ pub async fn create_modmail_thread(
 				.allowed_mentions(
 					serenity::CreateAllowedMentions::new()
 						.users([user_id])
-						.roles([data.mod_role_id]),
+						.roles([data.mod_role_id, data.mod_consultant_role_id]),
 				),
 		)
 		.await?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,7 @@ pub struct Data {
 	pub discord_guild_id: serenity::GuildId,
 	pub application_id: serenity::UserId,
 	pub mod_role_id: serenity::RoleId,
+	pub mod_consultant_role_id: serenity::RoleId,
 	pub rustacean_role_id: serenity::RoleId,
 	pub modmail_channel_id: serenity::ChannelId,
 	pub modlog_channel_id: serenity::ChannelId,
@@ -37,6 +38,9 @@ impl Data {
 			discord_guild_id: secret_store.get_discord_id("DISCORD_GUILD")?.into(),
 			application_id: secret_store.get_discord_id("APPLICATION_ID")?.into(),
 			mod_role_id: secret_store.get_discord_id("MOD_ROLE_ID")?.into(),
+			mod_consultant_role_id: secret_store
+				.get_discord_id("MOD_CONSULTANT_ROLE_ID")?
+				.into(),
 			rustacean_role_id: secret_store.get_discord_id("RUSTACEAN_ROLE_ID")?.into(),
 			modmail_channel_id: secret_store.get_discord_id("MODMAIL_CHANNEL_ID")?.into(),
 			modlog_channel_id: secret_store.get_discord_id("MODLOG_CHANNEL_ID")?.into(),


### PR DESCRIPTION
Staff are currently trialing a new "Mod Consultant" role which has permission to see moderation activities but does not have Discord management/infraction permissions. In that vein, we add them to modmails.

Once merged, the role ID should be added to the deployment environment.