### PR TITLE
honeycomb.io free tier abuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,11 +530,16 @@ dependencies = [
  "image",
  "imageproc",
  "itertools 0.14.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "poise",
  "proc-macro2",
  "rand 0.9.2",
  "regex",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-tracing",
  "serde",
  "serde_json",
  "snafu",
@@ -546,6 +551,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-log",
+ "tracing-opentelemetry",
  "tracing-panic",
  "tracing-subscriber",
 ]
@@ -756,6 +762,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +906,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -907,6 +933,19 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1247,6 +1286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1506,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1660,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1667,6 +1806,29 @@ dependencies = [
  "syn 2.0.114",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1889,6 +2051,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -1921,6 +2084,39 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit",
+ "opentelemetry",
+ "reqwest",
+ "reqwest-middleware",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -2889,6 +3085,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2896,11 +3118,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2987,6 +3213,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ futures = "0.3.31"
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.25", default-features = false }
 itertools = "0.14"
+opentelemetry = { version = "0.30.0", features = ["trace"] }
+opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace"] }
+opentelemetry_sdk = { version = "0.30.0", features = ["trace"] }
 poise = { version = "0.6", default-features = false, features = [
   "default",
   "handle_panics",
@@ -28,6 +31,8 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
+reqwest-middleware = { version = "0.4.2", features = ["json"] }
+reqwest-tracing = { version = "0.5.0", features = ["opentelemetry_0_30"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8.9"
@@ -47,5 +52,6 @@ tokio = { version = "1.47", features = ["rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-appender = "0.2.4"
 tracing-log = "0.2.0"
+tracing-opentelemetry = "0.31.0"
 tracing-panic = "0.1.2"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,6 +5,11 @@ use figment::{
 	Figment,
 	providers::{Env, Format as _, Serialized, Toml},
 };
+use opentelemetry::{KeyValue, trace::TracerProvider as _};
+use opentelemetry_sdk::{
+	Resource,
+	trace::{Sampler, SdkTracerProvider},
+};
 use serde::Deserialize;
 use serde_json::json;
 use snafu::{Report, ResultExt as _, Snafu};
@@ -206,6 +211,24 @@ fn main() {
 		}
 	};
 	let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+
+	// Build the OTel tracer provider before the subscriber so we can attach a
+	// tracing-opentelemetry layer that ships spans to Honeycomb (or any OTLP
+	// backend). Absent [telemetry] section disables it cleanly for local dev.
+	let tracer_provider = match config.telemetry.as_ref() {
+		Some(telemetry) => match Report::capture_into_result(|| build_tracer_provider(telemetry)) {
+			Ok(tp) => Some(tp),
+			Err(err) => {
+				error!(%err, "failed to init OpenTelemetry tracer provider");
+				return;
+			}
+		},
+		None => None,
+	};
+	let otel_layer = tracer_provider
+		.as_ref()
+		.map(|tp| tracing_opentelemetry::layer().with_tracer(tp.tracer("ferrisbot")));
+
 	let subscriber = match Report::capture_into_result(|| {
 		Ok::<_, AppError>(
 			Registry::default()
@@ -215,6 +238,7 @@ fn main() {
 						.with_writer(non_blocking),
 				)
 				.with(fmt::Layer::default().with_writer(std::io::stderr))
+				.with(otel_layer)
 				.with(
 					EnvFilter::builder()
 						.with_default_directive(LevelFilter::INFO.into())
@@ -253,6 +277,41 @@ fn main() {
 			warn!("shutdown because of panic")
 		}
 	}
+
+	// Flush any buffered spans before exit; the BatchSpanProcessor drops them
+	// otherwise. Best-effort: a failure here is not actionable.
+	if let Some(tp) = tracer_provider
+		&& let Err(e) = tp.shutdown()
+	{
+		warn!(error = %e, "OpenTelemetry tracer shutdown failed");
+	}
+}
+
+fn build_tracer_provider(cfg: &TelemetryConfig) -> Result<SdkTracerProvider, AppError> {
+	let exporter = opentelemetry_otlp::SpanExporter::builder()
+		.with_tonic()
+		.build()
+		.context(OtlpSnafu)?;
+
+	let provider = SdkTracerProvider::builder()
+		.with_batch_exporter(exporter)
+		.with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+			cfg.sample_rate,
+		))))
+		.with_resource(
+			Resource::builder()
+				.with_service_name(cfg.service_name.clone())
+				.with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
+				.with_attribute(KeyValue::new(
+					"deployment.environment.name",
+					cfg.deployment_environment.clone(),
+				))
+				.build(),
+		)
+		.build();
+
+	opentelemetry::global::set_tracer_provider(provider.clone());
+	Ok(provider)
 }
 
 fn check_for_config_files(main: &PathBuf, secrets: &PathBuf) {
@@ -289,5 +348,9 @@ enum AppError {
 	Serenity {
 		#[snafu(source(from(poise::serenity_prelude::Error, Box::new)))]
 		source: Box<poise::serenity_prelude::Error>,
+	},
+	#[snafu(display("failed to build OTLP span exporter"))]
+	Otlp {
+		source: opentelemetry_otlp::ExporterBuildError,
 	},
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -33,9 +33,18 @@ struct DatabaseConfig {
 }
 
 #[derive(Deserialize, Debug)]
+struct TelemetryConfig {
+	service_name: String,
+	deployment_environment: String,
+	sample_rate: f64,
+}
+
+#[derive(Deserialize, Debug)]
 struct Config {
 	log: LogConfig,
 	database: DatabaseConfig,
+	#[serde(default)]
+	telemetry: Option<TelemetryConfig>,
 	secrets: HashMap<String, String>,
 }
 

--- a/src/commands/crates.rs
+++ b/src/commands/crates.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, bail};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use reqwest::header;
+use reqwest_middleware::ClientWithMiddleware;
 use serde::Deserialize;
 use tracing::info;
 
@@ -34,7 +35,7 @@ struct Crate {
 }
 
 /// Queries the crates.io crates list for a specific crate
-async fn get_crate(http: &reqwest::Client, query: &str) -> Result<Crate> {
+async fn get_crate(http: &ClientWithMiddleware, query: &str) -> Result<Crate> {
 	info!("searching for crate `{}`", query);
 
 	let crate_list = http
@@ -436,7 +437,7 @@ trait DocsClient {
 	async fn page_exists(&self, url: &str) -> bool;
 }
 
-impl DocsClient for reqwest::Client {
+impl DocsClient for ClientWithMiddleware {
 	async fn get_crate_docs(&self, crate_name: &str) -> Result<String> {
 		get_crate(self, crate_name)
 			.await

--- a/src/commands/crates.rs
+++ b/src/commands/crates.rs
@@ -117,6 +117,16 @@ async fn autocomplete_crate(ctx: Context<'_>, partial: &str) -> impl Iterator<It
 	broadcast_typing,
 	category = "Crates"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn crate_(
 	ctx: Context<'_>,
 	#[description = "Name of the searched crate"]
@@ -225,6 +235,16 @@ fn rustc_crate_link(crate_name: &str) -> Option<&'static str> {
 	track_edits,
 	slash_command,
 	category = "Crates"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn doc(
 	ctx: Context<'_>,

--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -321,6 +321,16 @@ fn parse(args: &str) -> Result<(KeyValueArgs, String), CodeBlockError> {
 	reason = "not markdown, shown to end user"
 )]
 #[poise::command(prefix_command, category = "Godbolt", broadcast_typing, track_edits)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn godbolt(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Error> {
 	let (params, mut code) = parse(&arguments)?;
 	let no_mangle_added = add_no_mangle(&mut code);
@@ -375,6 +385,16 @@ pub async fn godbolt(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), 
 	reason = "not markdown, shown to end user"
 )]
 #[poise::command(prefix_command, category = "Godbolt", broadcast_typing, track_edits)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn mca(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Error> {
 	let (params, mut code) = parse(&arguments)?;
 	let no_mangle_added = add_no_mangle(&mut code);
@@ -413,6 +433,16 @@ pub async fn mca(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Erro
 	reason = "not markdown, shown to end user"
 )]
 #[poise::command(prefix_command, category = "Godbolt", broadcast_typing, track_edits)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn llvmir(ctx: Context<'_>, #[rest] arguments: String) -> Result<(), Error> {
 	let (params, mut code) = parse(&arguments)?;
 	let no_mangle_added = add_no_mangle(&mut code);

--- a/src/commands/godbolt.rs
+++ b/src/commands/godbolt.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, mem::take};
 
 use anyhow::{Error, anyhow};
 use poise::{CodeBlockError, KeyValueArgs};
+use reqwest_middleware::ClientWithMiddleware;
 use syn::spanned::Spanned;
 use tracing::warn;
 
@@ -73,7 +74,7 @@ struct GodboltRequest<'a> {
 /// full optimizations (-O3)
 /// Returns a multiline string with the pretty printed assembly
 async fn compile_rust_source(
-	http: &reqwest::Client,
+	http: &ClientWithMiddleware,
 	request: &GodboltRequest<'_>,
 ) -> Result<Compilation, Error> {
 	let tools = make_tools_json(request.run_llvm_mca);
@@ -116,7 +117,7 @@ async fn compile_rust_source(
 	})
 }
 
-async fn save_to_shortlink(http: &reqwest::Client, req: &GodboltRequest<'_>) -> String {
+async fn save_to_shortlink(http: &ClientWithMiddleware, req: &GodboltRequest<'_>) -> String {
 	#[derive(serde::Deserialize)]
 	struct GodboltShortenerResponse {
 		url: String,

--- a/src/commands/godbolt/targets.rs
+++ b/src/commands/godbolt/targets.rs
@@ -214,6 +214,16 @@ impl<'a> From<&'a str> for SemverRanking<'a> {
 
 /// Lists all available godbolt rustc targets
 #[poise::command(prefix_command, slash_command, broadcast_typing, category = "Godbolt")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn targets(ctx: Context<'_>) -> Result<(), Error> {
 	let mut targets = fetch_godbolt_metadata(ctx.data()).await.targets.clone();
 

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -16,12 +16,32 @@ use sqlx::{Pool, Sqlite};
 	subcommands("add", "remove", "list", "mat"),
 	subcommand_required
 )]
-pub async fn highlight(_: Context<'_>) -> Result<(), Error> {
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
+pub async fn highlight(ctx: Context<'_>) -> Result<(), Error> {
 	Ok(())
 }
 
 #[poise::command(prefix_command, slash_command)]
 /// Adds a highlight. When a highlight is matched, you will receive a DM.
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %c.command().qualified_name,
+		author.id = c.author().id.get(),
+		channel.id = c.channel_id().get(),
+		guild.id = c.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn add(c: Context<'_>, regex: String) -> Result<()> {
 	let db = require_database!(c);
 
@@ -40,6 +60,16 @@ pub async fn add(c: Context<'_>, regex: String) -> Result<()> {
 
 #[poise::command(prefix_command, slash_command)]
 /// Removes a highlight by ID.
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %c.command().qualified_name,
+		author.id = c.author().id.get(),
+		channel.id = c.channel_id().get(),
+		guild.id = c.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn remove(c: Context<'_>, id: i64) -> Result<()> {
 	let db = require_database!(c);
 
@@ -61,6 +91,16 @@ pub async fn remove(c: Context<'_>, id: i64) -> Result<()> {
 
 #[poise::command(prefix_command, slash_command)]
 /// Lists your current highlights
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %c.command().qualified_name,
+		author.id = c.author().id.get(),
+		channel.id = c.channel_id().get(),
+		guild.id = c.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn list(c: Context<'_>) -> Result<()> {
 	let db = require_database!(c);
 	let highlights = database::highlight_get(db, c.author().id).await?;
@@ -97,6 +137,16 @@ pub async fn matches(author: UserId, haystack: &str, db: &Pool<Sqlite>) -> Resul
 
 #[poise::command(prefix_command, slash_command, rename = "match")]
 /// Tests if your highlights match a given string
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %c.command().qualified_name,
+		author.id = c.author().id.get(),
+		channel.id = c.channel_id().get(),
+		guild.id = c.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn mat(c: Context<'_>, haystack: String) -> Result<()> {
 	let db = require_database!(c);
 	let x = matches(c.author().id, &haystack, db).await?;

--- a/src/commands/man.rs
+++ b/src/commands/man.rs
@@ -13,6 +13,16 @@ const USER_AGENT: &str = "kangalioo/rustbot";
 	broadcast_typing,
 	category = "Utilities"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn man(
 	ctx: Context<'_>,
 	#[description = "Section of the man page"] section: Option<String>,

--- a/src/commands/modmail.rs
+++ b/src/commands/modmail.rs
@@ -24,6 +24,16 @@ async fn send_modmail_success(ctx: Context<'_>, modmail: &GuildChannel) -> Resul
 	hide_in_help,
 	category = "Modmail"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn modmail_context_menu_for_message(
 	ctx: Context<'_>,
 	#[description = "Message to automatically link when opening a modmail"]
@@ -46,6 +56,16 @@ pub async fn modmail_context_menu_for_message(
 	context_menu_command = "Open Modmail",
 	hide_in_help,
 	category = "Modmail"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn modmail_context_menu_for_user(
 	ctx: Context<'_>,
@@ -75,6 +95,16 @@ pub async fn modmail_context_menu_for_user(
 ///
 /// You can still always ping the Moderator role if you're comfortable doing so.
 #[poise::command(prefix_command, slash_command, ephemeral, category = "Modmail")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn modmail(
 	ctx: Context<'_>,
 	#[description = "What would you like to say?"] user_message: String,

--- a/src/commands/moving.rs
+++ b/src/commands/moving.rs
@@ -25,6 +25,16 @@ const MAX_TIME_SPAN: Duration = Duration::from_hours(2);
 	required_permissions = "MANAGE_MESSAGES",
 	required_bot_permissions = "MANAGE_MESSAGES | MANAGE_WEBHOOKS | MANAGE_THREADS | SEND_MESSAGES_IN_THREADS"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn move_messages_context_menu(ctx: Context<'_>, msg: Message) -> Result<()> {
 	Box::pin(move_messages(ctx, msg)).await
 }

--- a/src/commands/playground/microbench.rs
+++ b/src/commands/playground/microbench.rs
@@ -66,6 +66,16 @@ fn bench(functions: &[(&str, fn())]) {
 	help_text_fn = "microbench_help",
 	category = "Playground"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn microbench(
 	ctx: Context<'_>,
 	flags: poise::KeyValueArgs,

--- a/src/commands/playground/misc_commands.rs
+++ b/src/commands/playground/misc_commands.rs
@@ -24,6 +24,16 @@ use super::{
 	help_text_fn = "miri_help",
 	category = "Playground"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn miri(
 	ctx: Context<'_>,
 	flags: poise::KeyValueArgs,
@@ -84,6 +94,16 @@ pub fn miri_help() -> String {
 	track_edits,
 	help_text_fn = "expand_help",
 	category = "Playground"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn expand(
 	ctx: Context<'_>,
@@ -161,6 +181,16 @@ pub fn expand_help() -> String {
 	help_text_fn = "clippy_help",
 	category = "Playground"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn clippy(
 	ctx: Context<'_>,
 	flags: poise::KeyValueArgs,
@@ -229,6 +259,16 @@ pub fn clippy_help() -> String {
 	track_edits,
 	help_text_fn = "fmt_help",
 	category = "Playground"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn fmt(
 	ctx: Context<'_>,

--- a/src/commands/playground/play_eval.rs
+++ b/src/commands/playground/play_eval.rs
@@ -61,6 +61,16 @@ async fn play_or_eval(
 	help_text_fn = "play_help",
 	category = "Playground"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn play(
 	ctx: Context<'_>,
 	flags: poise::KeyValueArgs,
@@ -89,6 +99,16 @@ hide_in_help, // don't clutter help menu with something that ?play can do too
 help_text_fn = "playwarn_help",
 category = "Playground"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn playwarn(
 	ctx: Context<'_>,
 	flags: poise::KeyValueArgs,
@@ -116,6 +136,16 @@ pub fn playwarn_help() -> String {
 	track_edits,
 	help_text_fn = "eval_help",
 	category = "Playground"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn eval(
 	ctx: Context<'_>,

--- a/src/commands/playground/procmacro.rs
+++ b/src/commands/playground/procmacro.rs
@@ -17,6 +17,16 @@ use super::{
 	help_text_fn = "procmacro_help",
 	category = "Playground"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn procmacro(
 	ctx: Context<'_>,
 	flags: poise::KeyValueArgs,

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -57,6 +57,16 @@ struct TagStatsMember {
 
 /// Display a tag.
 #[poise::command(slash_command, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tag(ctx: Context<'_>, name: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	let tag = database::tag_get(db, &name).await?;
@@ -84,6 +94,16 @@ pub async fn tag(ctx: Context<'_>, name: String) -> Result<(), Error> {
 		"tags_list",
 	)
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %_ctx.command().qualified_name,
+		author.id = _ctx.author().id.get(),
+		channel.id = _ctx.channel_id().get(),
+		guild.id = _ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags(_ctx: Context<'_>) -> Result<(), Error> {
 	// Can't be invoked directly
 	Ok(())
@@ -96,6 +116,16 @@ pub async fn tags(_ctx: Context<'_>) -> Result<(), Error> {
 	ephemeral,
 	category = "Tags",
 	aliases("add")
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn tags_create(ctx: Context<'_>, name: String, content: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
@@ -122,6 +152,16 @@ pub async fn tags_create(ctx: Context<'_>, name: String, content: String) -> Res
 	category = "Tags",
 	aliases("remove")
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_delete(ctx: Context<'_>, name: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	database::tag_delete(db, &name).await?;
@@ -132,6 +172,16 @@ pub async fn tags_delete(ctx: Context<'_>, name: String) -> Result<(), Error> {
 
 /// Creates an alias for an already existing tag so you can call it with either of the names.
 #[poise::command(rename = "alias", slash_command, ephemeral, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_alias(ctx: Context<'_>, existing: String, new: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	let tag_already_exists = database::tag_get(db, &new).await.is_ok();
@@ -149,6 +199,16 @@ pub async fn tags_alias(ctx: Context<'_>, existing: String, new: String) -> Resu
 
 /// Edits the content of an already existing tag.
 #[poise::command(rename = "edit", slash_command, ephemeral, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_edit(ctx: Context<'_>, name: String, content: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	let tag = database::tag_get(db, &name).await?;
@@ -170,6 +230,16 @@ pub async fn tags_edit(ctx: Context<'_>, name: String, content: String) -> Resul
 
 /// This will make the bot post the content in the bot-channel and ping the author upon being used.
 #[poise::command(rename = "restrict", slash_command, ephemeral, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_restrict(ctx: Context<'_>, name: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	database::tag_restrict(db, &name).await?;
@@ -180,6 +250,16 @@ pub async fn tags_restrict(ctx: Context<'_>, name: String) -> Result<(), Error> 
 
 /// Shows information about the server tags. If you mention someone, it will show their tags instead.
 #[poise::command(rename = "stats", slash_command, ephemeral, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_stats(ctx: Context<'_>, member: Option<serenity::UserId>) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	let embed = if let Some(member) = member {
@@ -270,6 +350,16 @@ async fn tags_member_stats(
 
 /// Shows some stats collected about the tag.
 #[poise::command(rename = "info", slash_command, ephemeral, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_info(ctx: Context<'_>, name: String) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	let tag = database::tag_get(db, &name).await?;
@@ -311,6 +401,16 @@ pub async fn tags_info(ctx: Context<'_>, name: String) -> Result<(), Error> {
 
 /// Lists all tags in the server. If you mention someone, it will show their tags instead.
 #[poise::command(rename = "list", slash_command, ephemeral, category = "Tags")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn tags_list(ctx: Context<'_>, member: Option<serenity::UserId>) -> Result<(), Error> {
 	let db = require_database!(ctx);
 	let tags = if let Some(member) = member {

--- a/src/commands/thread_pin.rs
+++ b/src/commands/thread_pin.rs
@@ -35,6 +35,16 @@ async fn can_pin_in_thread(ctx: Context<'_>) -> Result<(), ThreadPinError> {
 }
 
 #[poise::command(context_menu_command = "Pin Message to Thread", guild_only)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn thread_pin(ctx: Context<'_>, message: serenity::Message) -> Result<()> {
 	let reply = match can_pin_in_thread(ctx).await {
 		Ok(()) => {

--- a/src/commands/utilities.rs
+++ b/src/commands/utilities.rs
@@ -21,6 +21,16 @@ use crate::types::Context;
 	category = "Utilities",
 	discard_spare_arguments
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn go(ctx: Context<'_>) -> Result<(), Error> {
 	if rand::rng().random_bool(0.01) {
 		ctx.say("Yes").await?;
@@ -37,6 +47,16 @@ pub async fn go(ctx: Context<'_>) -> Result<(), Error> {
 	category = "Utilities",
 	discard_spare_arguments
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn source(ctx: Context<'_>) -> Result<(), Error> {
 	ctx.say("https://github.com/rust-community-discord/ferrisbot-for-discord")
 		.await?;
@@ -45,6 +65,16 @@ pub async fn source(ctx: Context<'_>) -> Result<(), Error> {
 
 /// Show this menu
 #[poise::command(prefix_command, slash_command, category = "Utilities", track_edits)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn help(
 	ctx: Context<'_>,
 	#[description = "Specific command to show help about"]
@@ -77,6 +107,16 @@ You can edit your message to the bot and the bot will edit its response.";
 	hide_in_help,
 	check = "crate::checks::check_is_moderator"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn register(ctx: Context<'_>) -> Result<(), Error> {
 	poise::builtins::register_application_commands_buttons(ctx).await?;
 
@@ -85,6 +125,16 @@ pub async fn register(ctx: Context<'_>) -> Result<(), Error> {
 
 /// Tells you how long the bot has been up for
 #[poise::command(prefix_command, slash_command, category = "Utilities")]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn uptime(ctx: Context<'_>) -> Result<(), Error> {
 	let uptime = ctx.data().bot_start_time.elapsed();
 
@@ -110,6 +160,16 @@ pub async fn uptime(ctx: Context<'_>) -> Result<(), Error> {
 	category = "Utilities",
 	track_edits,
 	hide_in_help
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn conradluget(
 	ctx: Context<'_>,
@@ -172,6 +232,16 @@ pub async fn conradluget(
 	category = "Utilities",
 	on_error = "crate::helpers::acknowledge_fail"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn cleanup(
 	ctx: Context<'_>,
 	#[description = "Number of messages to delete"] num_messages: Option<usize>,
@@ -207,6 +277,16 @@ pub async fn cleanup(
 	category = "Utilities",
 	on_error = "crate::helpers::acknowledge_fail"
 )]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn ban(
 	ctx: Context<'_>,
 	#[description = "Banned user"] banned_user: serenity::Member,
@@ -235,6 +315,16 @@ pub async fn ban(
 	slash_command,
 	category = "Utilities",
 	on_error = "crate::helpers::acknowledge_fail"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn selftimeout(
 	ctx: Context<'_>,
@@ -276,6 +366,16 @@ pub async fn selftimeout(
 	prefix_command,
 	category = "Utilities",
 	discard_spare_arguments // to allow smooth integration in the closing message, e.g. "?solved, thank you"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
 	let mut thread = ctx
@@ -321,6 +421,16 @@ pub async fn solved(ctx: Context<'_>) -> Result<(), Error> {
 	category = "Utilities",
 	check = "crate::checks::check_is_moderator",
 	on_error = "crate::helpers::acknowledge_fail"
+)]
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
 )]
 pub async fn edit(
 	ctx: Context<'_>,
@@ -402,6 +512,16 @@ pub async fn edit(
 	on_error = "crate::helpers::acknowledge_fail"
 )]
 /// Shows information about the server
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
 	let guild = ctx
 		.guild()
@@ -454,6 +574,16 @@ pub async fn server(ctx: Context<'_>) -> Result<(), Error> {
 	on_error = "crate::helpers::acknowledge_fail"
 )]
 /// Shows information about a user
+#[tracing::instrument(
+	skip_all,
+	fields(
+		command = %ctx.command().qualified_name,
+		author.id = ctx.author().id.get(),
+		channel.id = ctx.channel_id().get(),
+		guild.id = ctx.guild_id().map(poise::serenity_prelude::GuildId::get),
+	),
+	err(Debug),
+)]
 pub async fn user(
 	ctx: Context<'_>,
 	#[description = "User to get information about"] user: Option<serenity::User>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@ use std::{
 
 use anyhow::{Error, Result};
 use poise::serenity_prelude as serenity;
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_tracing::TracingMiddleware;
 use tokio::sync::RwLock;
 
 use crate::{SecretStore, commands};
@@ -21,7 +23,7 @@ pub struct Data {
 	pub modlog_channel_id: serenity::ChannelId,
 	pub modmail_message: Arc<tokio::sync::RwLock<Option<serenity::Message>>>,
 	pub bot_start_time: std::time::Instant,
-	pub http: reqwest::Client,
+	pub http: ClientWithMiddleware,
 	pub godbolt_metadata: StdMutex<commands::godbolt::GodboltMetadata>,
 	pub move_channel_locks: StdMutex<HashSet<serenity::ChannelId>>,
 }
@@ -42,7 +44,9 @@ impl Data {
 			modlog_channel_id: secret_store.get_discord_id("MODLOG_CHANNEL_ID")?.into(),
 			modmail_message: Arc::default(),
 			bot_start_time: std::time::Instant::now(),
-			http: reqwest::Client::new(),
+			http: ClientBuilder::new(reqwest::Client::new())
+				.with(TracingMiddleware::default())
+				.build(),
 			godbolt_metadata: StdMutex::new(commands::godbolt::GodboltMetadata::default()),
 			move_channel_locks: StdMutex::new(HashSet::new()),
 		})


### PR DESCRIPTION
Configure opentelemetry and honeycomb so we can start getting some better observability. Setting the sample rate low right now to not blow through the free tier allowance incase there's a lot of traces.

Unfortunately I couldn't find a way to automatically trace all poise commands (I could log an event during pre_command and post_command, but not set up a trace span). Maybe I'm missing something.