### PR TITLE
`/highlight` improvements: case-insensitivity, debouncing, non-self-trigger, no-emojis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install cargo-sqlx
       uses: taiki-e/install-action@v2
       with:
-        tool: sqlx-cli
+        tool: sqlx-cli@0.8.6
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
@@ -88,7 +88,7 @@ jobs:
     - name: Install cargo-sqlx
       uses: taiki-e/install-action@v2
       with:
-        tool: sqlx-cli
+        tool: sqlx-cli@0.8.6
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "anyhow",
  "figment",
  "futures",
+ "humantime-serde",
  "image",
  "imageproc",
  "itertools 0.14.0",
@@ -870,6 +871,22 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ ab_glyph = { version = "0.2", default-features = false }
 anyhow = "1.0"
 figment = { version = "0.10.19", features = ["env", "toml"] }
 futures = "0.3.31"
+humantime-serde = "1.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.25", default-features = false }
 itertools = "0.14"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -33,9 +33,16 @@ struct DatabaseConfig {
 }
 
 #[derive(Deserialize, Debug)]
+struct HighlightConfig {
+	#[serde(with = "humantime_serde")]
+	cooldown: std::time::Duration,
+}
+
+#[derive(Deserialize, Debug)]
 struct Config {
 	log: LogConfig,
 	database: DatabaseConfig,
+	highlight: HighlightConfig,
 	secrets: HashMap<String, String>,
 }
 
@@ -53,6 +60,9 @@ static DEFAULT_CONFIG: LazyLock<serde_json::Value> = LazyLock::new(|| {
 		"database": {
 			"disabled": false,
 			"url": "sqlite://database/ferris.sqlite3"
+		},
+		"highlight": {
+			"cooldown": "5m"
 		},
 		"secrets": {}
 	})
@@ -107,9 +117,10 @@ fn app(config: &Config) -> Result<(), AppError> {
 				.collect(),
 		);
 
-		let mut client = ferrisbot_for_discord::serenity(secret_store, pool)
-			.await
-			.context(SerenityInitSnafu)?;
+		let mut client =
+			ferrisbot_for_discord::serenity(secret_store, pool, config.highlight.cooldown)
+				.await
+				.context(SerenityInitSnafu)?;
 
 		info!("starting serenity...");
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fs, panic, path::PathBuf, str::FromStr, sync::LazyLock};
 
-use ferrisbot_for_discord::SecretStore;
+use ferrisbot_for_discord::{SecretStore, commands::highlight::HighlightConfig};
 use figment::{
 	Figment,
 	providers::{Env, Format as _, Serialized, Toml},
@@ -30,12 +30,6 @@ struct DatabaseConfig {
 	#[serde(default)]
 	disabled: bool,
 	url: String,
-}
-
-#[derive(Deserialize, Debug)]
-struct HighlightConfig {
-	#[serde(with = "humantime_serde")]
-	cooldown: std::time::Duration,
 }
 
 #[derive(Deserialize, Debug)]
@@ -117,10 +111,9 @@ fn app(config: &Config) -> Result<(), AppError> {
 				.collect(),
 		);
 
-		let mut client =
-			ferrisbot_for_discord::serenity(secret_store, pool, config.highlight.cooldown)
-				.await
-				.context(SerenityInitSnafu)?;
+		let mut client = ferrisbot_for_discord::serenity(secret_store, pool, config.highlight)
+			.await
+			.context(SerenityInitSnafu)?;
 
 		info!("starting serenity...");
 

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -216,10 +216,9 @@ pub struct HighlightCooldowns {
 }
 
 impl HighlightCooldowns {
-	#[must_use]
-	pub fn new(config: HighlightConfig) -> Self {
+	pub fn new(HighlightConfig { cooldown }: HighlightConfig) -> Self {
 		Self {
-			window: config.cooldown,
+			window: cooldown,
 			expiries: HashMap::new(),
 			next_prune: Instant::now(),
 		}

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -107,24 +107,13 @@ pub async fn list(c: Context<'_>) -> Result<()> {
 	Ok(())
 }
 
-pub async fn matches(author: UserId, haystack: &str, db: &Pool<Sqlite>) -> Result<Vec<String>> {
-	let patterns = database::highlight_get(db, author).await?;
-	Ok(patterns
-		.into_iter()
-		.filter_map(|(_id, pattern)| {
-			compile_pattern(&pattern)
-				.ok()
-				.filter(|regex| regex.is_match(haystack))
-				.map(|_| pattern)
-		})
-		.collect())
-}
-
 #[poise::command(prefix_command, slash_command, rename = "match")]
 /// Tests if your highlights match a given string
 pub async fn mat(c: Context<'_>, haystack: String) -> Result<()> {
-	let db = require_database!(c);
-	let x = matches(c.author().id, &haystack, db).await?;
+	let x = {
+		let hl = c.data().highlights.read().await;
+		hl.find_for_user(c.author().id, &haystack)
+	};
 
 	poise::send_reply(
 		c,
@@ -186,13 +175,27 @@ impl RegexHolder {
 		*data.highlights.write().await = new;
 	}
 
+	fn matches<'a>(
+		entries: impl Iterator<Item = &'a (UserId, Regex)> + 'a,
+		haystack: &'a str,
+	) -> impl Iterator<Item = (UserId, &'a Regex)> {
+		let haystack = sanitize_content(haystack);
+		entries
+			.filter(move |(_, regex)| regex.is_match(&haystack))
+			.map(|(user_id, regex)| (*user_id, regex))
+	}
+
 	#[must_use]
 	pub fn find(&self, haystack: &str) -> HashMap<UserId, String> {
-		let haystack = sanitize_content(haystack);
-		self.0
-			.iter()
-			.filter(|&(_user_id, regex)| regex.is_match(&haystack))
-			.map(|(user_id, regex)| (*user_id, regex.as_str().to_string()))
+		Self::matches(self.0.iter(), haystack)
+			.map(|(user_id, regex)| (user_id, regex.as_str().to_owned()))
+			.collect()
+	}
+
+	#[must_use]
+	pub fn find_for_user(&self, user: UserId, haystack: &str) -> Vec<String> {
+		Self::matches(self.0.iter().filter(move |(id, _)| *id == user), haystack)
+			.map(|(_, regex)| regex.as_str().to_owned())
 			.collect()
 	}
 }

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -25,7 +25,11 @@ pub async fn highlight(_: Context<'_>) -> Result<(), Error> {
 pub async fn add(c: Context<'_>, regex: String) -> Result<()> {
 	let db = require_database!(c);
 
-	if let Err(e) = RegexBuilder::new(&regex).size_limit(1 << 10).build() {
+	if let Err(e) = RegexBuilder::new(&regex)
+		.size_limit(1 << 10)
+		.case_insensitive(true)
+		.build()
+	{
 		c.say(format!("```\n{e}```")).await?;
 		return Ok(());
 	}
@@ -87,7 +91,9 @@ pub async fn matches(author: UserId, haystack: &str, db: &Pool<Sqlite>) -> Resul
 	Ok(patterns
 		.into_iter()
 		.filter_map(|(_id, pattern)| {
-			Regex::new(&pattern)
+			RegexBuilder::new(&pattern)
+				.case_insensitive(true)
+				.build()
 				.ok()
 				.filter(|regex| regex.is_match(haystack))
 				.map(|_| pattern)
@@ -134,11 +140,13 @@ impl RegexHolder {
 
 		let entries = rows
 			.into_iter()
-			.filter_map(|(member_id, highlight)| match Regex::new(&highlight) {
-				Ok(regex) => Some((UserId::new(member_id.cast_unsigned()), regex)),
-				Err(e) => {
-					warn!("Invalid regex pattern '{highlight}' for member {member_id}: {e}");
-					None
+			.filter_map(|(member_id, highlight)| {
+				match RegexBuilder::new(&highlight).case_insensitive(true).build() {
+					Ok(regex) => Some((UserId::new(member_id.cast_unsigned()), regex)),
+					Err(e) => {
+						warn!("Invalid regex pattern '{highlight}' for member {member_id}: {e}");
+						None
+					}
 				}
 			})
 			.collect();

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 use crate::{require_database, types::Context};
 use anyhow::{Error, Result};
 use poise::{
 	CreateReply,
-	serenity_prelude::{CreateEmbed, UserId},
+	serenity_prelude::{ChannelId, CreateEmbed, UserId},
 };
 use regex::{Regex, RegexBuilder};
 use sqlx::{Pool, Sqlite};
@@ -176,6 +178,55 @@ impl RegexHolder {
 			.filter(|&(_user_id, regex)| regex.is_match(&haystack))
 			.map(|(user_id, regex)| (*user_id, regex.as_str().to_string()))
 			.collect()
+	}
+}
+
+/// Per-`(user, channel)` cooldown expiry instants. Expired entries are swept
+/// lazily (at most once per window) by `mark_active`, so `try_notify` needn't prune.
+#[derive(Debug)]
+pub struct HighlightCooldowns {
+	window: Duration,
+	expiries: HashMap<(UserId, ChannelId), Instant>,
+	next_prune: Instant,
+}
+
+impl HighlightCooldowns {
+	#[must_use]
+	pub fn new(window: Duration) -> Self {
+		Self {
+			window,
+			expiries: HashMap::new(),
+			next_prune: Instant::now(),
+		}
+	}
+
+	/// Refreshes the cooldown unconditionally (the user posted, so don't ping them).
+	pub fn mark_active(&mut self, user: UserId, channel: ChannelId, now: Instant) {
+		self.expiries.insert((user, channel), now + self.window);
+		self.prune_amortised(now);
+	}
+
+	/// Starts a cooldown unless one is active; returns whether to send a DM.
+	pub fn try_notify(&mut self, user: UserId, channel: ChannelId, now: Instant) -> bool {
+		match self.expiries.entry((user, channel)) {
+			Entry::Occupied(entry) if *entry.get() > now => false,
+			Entry::Occupied(mut entry) => {
+				entry.insert(now + self.window);
+				true
+			}
+			Entry::Vacant(entry) => {
+				entry.insert(now + self.window);
+				true
+			}
+		}
+	}
+
+	fn prune_amortised(&mut self, now: Instant) {
+		if now < self.next_prune {
+			return;
+		}
+		self.expiries.retain(|_, expiry| *expiry > now);
+		self.next_prune = now + self.window;
 	}
 }
 

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -10,6 +10,7 @@ use poise::{
 	serenity_prelude::{ChannelId, CreateEmbed, UserId},
 };
 use regex::{Regex, RegexBuilder};
+use serde::Deserialize;
 use sqlx::{Pool, Sqlite};
 
 #[cfg(test)]
@@ -195,6 +196,12 @@ impl RegexHolder {
 	}
 }
 
+#[derive(Deserialize, Debug, Clone, Copy)]
+pub struct HighlightConfig {
+	#[serde(with = "humantime_serde")]
+	cooldown: std::time::Duration,
+}
+
 /// Per-`(user, channel)` cooldown expiry instants. Expired entries are swept
 /// lazily (at most once per window) by `mark_active`, so `try_notify` needn't prune.
 #[derive(Debug)]
@@ -206,9 +213,9 @@ pub struct HighlightCooldowns {
 
 impl HighlightCooldowns {
 	#[must_use]
-	pub fn new(window: Duration) -> Self {
+	pub fn new(config: HighlightConfig) -> Self {
 		Self {
-			window,
+			window: config.cooldown,
 			expiries: HashMap::new(),
 			next_prune: Instant::now(),
 		}

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -20,6 +20,11 @@ fn sanitize_content(content: &str) -> String {
 	CUSTOM_EMOJI.replace_all(content, " ").into_owned()
 }
 
+/// Compiles a pattern; case-insensitive unless the inline `(?-i)` flag is set.
+fn compile_pattern(pattern: &str) -> Result<Regex, regex::Error> {
+	RegexBuilder::new(pattern).case_insensitive(true).build()
+}
+
 #[allow(clippy::unused_async)]
 #[poise::command(
 	prefix_command,
@@ -102,9 +107,7 @@ pub async fn matches(author: UserId, haystack: &str, db: &Pool<Sqlite>) -> Resul
 	Ok(patterns
 		.into_iter()
 		.filter_map(|(_id, pattern)| {
-			RegexBuilder::new(&pattern)
-				.case_insensitive(true)
-				.build()
+			compile_pattern(&pattern)
 				.ok()
 				.filter(|regex| regex.is_match(haystack))
 				.map(|_| pattern)
@@ -149,15 +152,23 @@ impl RegexHolder {
 			}
 		};
 
-		let entries = rows
+		Self::from_patterns(
+			rows.into_iter()
+				.map(|(member_id, highlight)| (UserId::new(member_id.cast_unsigned()), highlight)),
+		)
+	}
+
+	/// Compiles `(user, pattern)` pairs into a holder, skipping invalid patterns.
+	fn from_patterns(patterns: impl IntoIterator<Item = (UserId, String)>) -> Self {
+		use tracing::warn;
+
+		let entries = patterns
 			.into_iter()
-			.filter_map(|(member_id, highlight)| {
-				match RegexBuilder::new(&highlight).case_insensitive(true).build() {
-					Ok(regex) => Some((UserId::new(member_id.cast_unsigned()), regex)),
-					Err(e) => {
-						warn!("Invalid regex pattern '{highlight}' for member {member_id}: {e}");
-						None
-					}
+			.filter_map(|(member_id, highlight)| match compile_pattern(&highlight) {
+				Ok(regex) => Some((member_id, regex)),
+				Err(e) => {
+					warn!("Invalid regex pattern '{highlight}' for member {member_id}: {e}");
+					None
 				}
 			})
 			.collect();

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::LazyLock;
@@ -20,8 +21,8 @@ static CUSTOM_EMOJI: LazyLock<Regex> =
 	LazyLock::new(|| Regex::new(r"<a?:\w+:\d+>").expect("valid custom-emoji regex"));
 
 /// Strips Discord custom-emoji markup so patterns don't match emoji names.
-fn sanitize_content(content: &str) -> String {
-	CUSTOM_EMOJI.replace_all(content, " ").into_owned()
+fn sanitize_content(content: &str) -> Cow<'_, str> {
+	CUSTOM_EMOJI.replace_all(content, " ")
 }
 
 /// Compiles a pattern; case-insensitive unless the inline `(?-i)` flag is set.

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use crate::{require_database, types::Context};
 use anyhow::{Error, Result};
@@ -8,6 +9,14 @@ use poise::{
 };
 use regex::{Regex, RegexBuilder};
 use sqlx::{Pool, Sqlite};
+
+static CUSTOM_EMOJI: LazyLock<Regex> =
+	LazyLock::new(|| Regex::new(r"<a?:\w+:\d+>").expect("valid custom-emoji regex"));
+
+/// Strips Discord custom-emoji markup so patterns don't match emoji names.
+fn sanitize_content(content: &str) -> String {
+	CUSTOM_EMOJI.replace_all(content, " ").into_owned()
+}
 
 #[allow(clippy::unused_async)]
 #[poise::command(
@@ -161,9 +170,10 @@ impl RegexHolder {
 
 	#[must_use]
 	pub fn find(&self, haystack: &str) -> HashMap<UserId, String> {
+		let haystack = sanitize_content(haystack);
 		self.0
 			.iter()
-			.filter(|&(_user_id, regex)| regex.is_match(haystack))
+			.filter(|&(_user_id, regex)| regex.is_match(&haystack))
 			.map(|(user_id, regex)| (*user_id, regex.as_str().to_string()))
 			.collect()
 	}

--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -12,6 +12,9 @@ use poise::{
 use regex::{Regex, RegexBuilder};
 use sqlx::{Pool, Sqlite};
 
+#[cfg(test)]
+mod tests;
+
 static CUSTOM_EMOJI: LazyLock<Regex> =
 	LazyLock::new(|| Regex::new(r"<a?:\w+:\d+>").expect("valid custom-emoji regex"));
 

--- a/src/commands/highlight/tests.rs
+++ b/src/commands/highlight/tests.rs
@@ -2,9 +2,12 @@ use std::time::{Duration, Instant};
 
 use poise::serenity_prelude::{ChannelId, UserId};
 
+use crate::commands::highlight::HighlightConfig;
+
 use super::{HighlightCooldowns, RegexHolder, sanitize_content};
 
 const WINDOW: Duration = Duration::from_mins(1);
+const CONFIG: HighlightConfig = HighlightConfig { cooldown: WINDOW };
 
 fn holder(patterns: &[(u64, &str)]) -> RegexHolder {
 	RegexHolder::from_patterns(
@@ -61,7 +64,7 @@ fn invalid_patterns_are_skipped() {
 
 #[test]
 fn try_notify_respects_window() {
-	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let mut cooldowns = HighlightCooldowns::new(CONFIG);
 	let (user, channel) = (UserId::new(1), ChannelId::new(2));
 	let now = Instant::now();
 
@@ -74,7 +77,7 @@ fn try_notify_respects_window() {
 
 #[test]
 fn activity_suppresses_notification() {
-	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let mut cooldowns = HighlightCooldowns::new(CONFIG);
 	let (user, channel) = (UserId::new(1), ChannelId::new(2));
 	let now = Instant::now();
 
@@ -84,7 +87,7 @@ fn activity_suppresses_notification() {
 
 #[test]
 fn expired_entries_are_pruned_when_sweep_fires() {
-	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let mut cooldowns = HighlightCooldowns::new(CONFIG);
 	let now = Instant::now();
 	cooldowns.mark_active(UserId::new(1), ChannelId::new(1), now);
 	assert_eq!(cooldowns.expiries.len(), 1);
@@ -102,7 +105,7 @@ fn expired_entries_are_pruned_when_sweep_fires() {
 
 #[test]
 fn pruning_is_amortised_within_window() {
-	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let mut cooldowns = HighlightCooldowns::new(CONFIG);
 	let now = Instant::now();
 	cooldowns.mark_active(UserId::new(1), ChannelId::new(1), now);
 

--- a/src/commands/highlight/tests.rs
+++ b/src/commands/highlight/tests.rs
@@ -1,0 +1,120 @@
+use std::time::{Duration, Instant};
+
+use poise::serenity_prelude::{ChannelId, UserId};
+
+use super::{HighlightCooldowns, RegexHolder, sanitize_content};
+
+const WINDOW: Duration = Duration::from_mins(1);
+
+fn holder(patterns: &[(u64, &str)]) -> RegexHolder {
+	RegexHolder::from_patterns(
+		patterns
+			.iter()
+			.map(|&(id, pattern)| (UserId::new(id), pattern.to_owned())),
+	)
+}
+
+#[test]
+fn sanitize_strips_custom_emoji_markup() {
+	assert!(!sanitize_content("meow <a:ferrisPet:755501265454366801>!").contains("ferris"));
+	assert!(!sanitize_content("<:conradBall:1508889024344100985>").contains("conrad"));
+}
+
+#[test]
+fn sanitize_keeps_plain_text_and_unicode_emoji() {
+	assert_eq!(sanitize_content("plain text 🦀"), "plain text 🦀");
+}
+
+#[test]
+fn matching_is_case_insensitive_by_default() {
+	let hl = holder(&[(1, "rust")]);
+	assert!(
+		hl.find("ferrisbot is programmed in Rust")
+			.contains_key(&UserId::new(1))
+	);
+}
+
+#[test]
+fn case_sensitivity_can_be_opted_out() {
+	let hl = holder(&[(1, "(?-i)rust")]);
+	assert!(hl.find("Rust").is_empty());
+	assert!(hl.find("rust").contains_key(&UserId::new(1)));
+}
+
+#[test]
+fn custom_emoji_names_do_not_match() {
+	let hl = holder(&[(1, "ferris")]);
+	assert!(hl.find("<:ferrisClueless:1180624887707074641>").is_empty());
+	assert!(
+		hl.find("hey, ferris is cute!")
+			.contains_key(&UserId::new(1))
+	);
+}
+
+#[test]
+fn invalid_patterns_are_skipped() {
+	let hl = holder(&[(1, "("), (2, "valid")]);
+	let recipients = hl.find("this is valid");
+	assert!(recipients.contains_key(&UserId::new(2)));
+	assert!(!recipients.contains_key(&UserId::new(1)));
+}
+
+#[test]
+fn try_notify_respects_window() {
+	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let (user, channel) = (UserId::new(1), ChannelId::new(2));
+	let now = Instant::now();
+
+	assert!(cooldowns.try_notify(user, channel, now));
+	assert!(!cooldowns.try_notify(user, channel, now));
+
+	let after = now + WINDOW + Duration::from_millis(1);
+	assert!(cooldowns.try_notify(user, channel, after));
+}
+
+#[test]
+fn activity_suppresses_notification() {
+	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let (user, channel) = (UserId::new(1), ChannelId::new(2));
+	let now = Instant::now();
+
+	cooldowns.mark_active(user, channel, now);
+	assert!(!cooldowns.try_notify(user, channel, now));
+}
+
+#[test]
+fn expired_entries_are_pruned_when_sweep_fires() {
+	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let now = Instant::now();
+	cooldowns.mark_active(UserId::new(1), ChannelId::new(1), now);
+	assert_eq!(cooldowns.expiries.len(), 1);
+
+	let later = now + WINDOW + Duration::from_secs(1);
+	cooldowns.mark_active(UserId::new(2), ChannelId::new(2), later);
+
+	assert_eq!(cooldowns.expiries.len(), 1);
+	assert!(
+		cooldowns
+			.expiries
+			.contains_key(&(UserId::new(2), ChannelId::new(2)))
+	);
+}
+
+#[test]
+fn pruning_is_amortised_within_window() {
+	let mut cooldowns = HighlightCooldowns::new(WINDOW);
+	let now = Instant::now();
+	cooldowns.mark_active(UserId::new(1), ChannelId::new(1), now);
+
+	// Already-expired entry must survive a sweep-free (amortised) call.
+	cooldowns
+		.expiries
+		.insert((UserId::new(9), ChannelId::new(9)), now);
+	cooldowns.mark_active(UserId::new(2), ChannelId::new(2), now);
+
+	assert!(
+		cooldowns
+			.expiries
+			.contains_key(&(UserId::new(9), ChannelId::new(9)))
+	);
+}

--- a/src/commands/highlight/tests.rs
+++ b/src/commands/highlight/tests.rs
@@ -55,6 +55,24 @@ fn custom_emoji_names_do_not_match() {
 }
 
 #[test]
+fn find_for_user_returns_only_the_authors_matches() {
+	let hl = holder(&[(1, "foo"), (1, "bar"), (2, "foo")]);
+	let mut m = hl.find_for_user(UserId::new(1), "foo bar baz");
+	m.sort();
+	assert_eq!(m, vec!["bar".to_string(), "foo".to_string()]);
+	assert!(hl.find_for_user(UserId::new(3), "foo").is_empty());
+}
+
+#[test]
+fn find_for_user_sanitizes_custom_emoji() {
+	let hl = holder(&[(1, "ferris")]);
+	assert!(
+		hl.find_for_user(UserId::new(1), "<:ferrisClueless:1180624887707074641>")
+			.is_empty()
+	);
+}
+
+#[test]
 fn invalid_patterns_are_skipped() {
 	let hl = holder(&[(1, "("), (2, "valid")]);
 	let recipients = hl.find("this is valid");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use poise::serenity_prelude::{self as serenity, ChannelType, Permissions};
 use rand::{Rng, seq::IteratorRandom};
 use tracing::{debug, info, warn};
 
+use crate::commands::highlight::HighlightConfig;
 use crate::commands::modmail::{create_modmail_thread, load_or_create_modmail_message};
 use crate::types::Data;
 
@@ -68,7 +69,7 @@ impl From<serenity::Client> for ShuttleSerenity {
 pub async fn serenity(
 	secret_store: SecretStore,
 	database: Option<sqlx::SqlitePool>,
-	highlight_cooldown: Duration,
+	highlight: HighlightConfig,
 ) -> Result<ShuttleSerenity, Error> {
 	let token = secret_store
 		.get("DISCORD_TOKEN")
@@ -86,7 +87,7 @@ pub async fn serenity(
 	let framework = poise::Framework::builder()
 		.setup(move |ctx, ready, framework| {
 			Box::pin(async move {
-				let data = Data::new(&secret_store, database, highlight_cooldown).await?;
+				let data = Data::new(&secret_store, database, highlight).await?;
 
 				info!(
 					"Registering {} commands...",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ impl From<serenity::Client> for ShuttleSerenity {
 pub async fn serenity(
 	secret_store: SecretStore,
 	database: Option<sqlx::SqlitePool>,
+	highlight_cooldown: Duration,
 ) -> Result<ShuttleSerenity, Error> {
 	let token = secret_store
 		.get("DISCORD_TOKEN")
@@ -85,7 +86,7 @@ pub async fn serenity(
 	let framework = poise::Framework::builder()
 		.setup(move |ctx, ready, framework| {
 			Box::pin(async move {
-				let data = Data::new(&secret_store, database).await?;
+				let data = Data::new(&secret_store, database, highlight_cooldown).await?;
 
 				info!(
 					"Registering {} commands...",
@@ -304,6 +305,16 @@ async fn event_handler(
 			if let Some(gid) = new_message.guild_id
 				&& !new_message.author.bot
 			{
+				// Author is active in this channel, so don't ping them.
+				let now = std::time::Instant::now();
+				{
+					let (Ok(mut cooldowns) | Err(mut cooldowns)) = data
+						.highlight_cooldowns
+						.lock()
+						.map_err(std::sync::PoisonError::into_inner);
+					cooldowns.mark_active(new_message.author.id, new_message.channel_id, now);
+				}
+
 				let hl = data.highlights.read().await;
 				let matches = hl.find(&new_message.content);
 				let message_link = new_message.link();
@@ -336,6 +347,16 @@ async fn event_handler(
 									.ok()
 									.map(|x| x.user_id) == Some(member.user.id))
 						{
+							{
+								let now = std::time::Instant::now();
+								let (Ok(mut cooldowns) | Err(mut cooldowns)) = data
+									.highlight_cooldowns
+									.lock()
+									.map_err(std::sync::PoisonError::into_inner);
+								if !cooldowns.try_notify(person_id, new_message.channel_id, now) {
+									return;
+								}
+							}
 							_ = person_id
 								.direct_message(
 									ctx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,8 @@ async fn event_handler(
 				let message_link = &*message_link;
 				let mut stream = futures::stream::iter(matches)
 					.map(|(person_id, matcher)| async move {
-						if let Ok(member) = gid.member(ctx, person_id).await
+						if person_id != new_message.author.id
+							&& let Ok(member) = gid.member(ctx, person_id).await
 							&& let Ok(p) = gid.to_partial_guild(ctx).await
 							&& let Ok(Some(channel)) = if let Ok(Some(x)) = p
 								.channels(ctx)

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,14 +1,16 @@
 use std::{
 	collections::HashSet,
 	sync::{Arc, Mutex as StdMutex},
-	time::Duration,
 };
 
 use anyhow::{Error, Result};
 use poise::serenity_prelude as serenity;
 use tokio::sync::RwLock;
 
-use crate::{SecretStore, commands};
+use crate::{
+	SecretStore,
+	commands::{self, highlight::HighlightConfig},
+};
 
 #[derive(Debug)]
 pub struct Data {
@@ -33,12 +35,12 @@ impl Data {
 	pub async fn new(
 		secret_store: &SecretStore,
 		database: Option<sqlx::SqlitePool>,
-		highlight_cooldown: Duration,
+		highlight: HighlightConfig,
 	) -> Result<Self> {
 		Ok(Self {
 			highlights: RwLock::new(commands::highlight::RegexHolder::new(database.as_ref()).await),
 			highlight_cooldowns: StdMutex::new(commands::highlight::HighlightCooldowns::new(
-				highlight_cooldown,
+				highlight,
 			)),
 			database,
 			discord_guild_id: secret_store.get_discord_id("DISCORD_GUILD")?.into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use std::{
 	collections::HashSet,
 	sync::{Arc, Mutex as StdMutex},
+	time::Duration,
 };
 
 use anyhow::{Error, Result};
@@ -12,6 +13,7 @@ use crate::{SecretStore, commands};
 #[derive(Debug)]
 pub struct Data {
 	pub highlights: RwLock<commands::highlight::RegexHolder>,
+	pub highlight_cooldowns: StdMutex<commands::highlight::HighlightCooldowns>,
 	pub database: Option<sqlx::SqlitePool>,
 	pub discord_guild_id: serenity::GuildId,
 	pub application_id: serenity::UserId,
@@ -31,9 +33,13 @@ impl Data {
 	pub async fn new(
 		secret_store: &SecretStore,
 		database: Option<sqlx::SqlitePool>,
+		highlight_cooldown: Duration,
 	) -> Result<Self> {
 		Ok(Self {
 			highlights: RwLock::new(commands::highlight::RegexHolder::new(database.as_ref()).await),
+			highlight_cooldowns: StdMutex::new(commands::highlight::HighlightCooldowns::new(
+				highlight_cooldown,
+			)),
 			database,
 			discord_guild_id: secret_store.get_discord_id("DISCORD_GUILD")?.into(),
 			application_id: secret_store.get_discord_id("APPLICATION_ID")?.into(),


### PR DESCRIPTION
?@conradludgate a better bot `highlight` command

Main changes:
* Regex is case-insensitive by default. Opt out by using `(?-i)`.
* Highlights no longer fire for self-messages. Use `/highlight match` for testing.
* Highlights no longer trigger for emojis. :conradBall:.
* Highlights are less noisy. If you're active in a conversation, or if you already received a highlight recently, it wont fire again for a few minutes.