### PR TITLE
Add bangs (like helium / firefox) to make it easier to reference gh and other relevant links. 

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,7 @@
 pub use godbolt::*;
 pub use playground::*;
 
+pub mod bangs;
 pub mod crates;
 pub mod godbolt;
 pub mod highlight;

--- a/src/commands/bangs.rs
+++ b/src/commands/bangs.rs
@@ -31,8 +31,11 @@ pub async fn duckduckgo_bang(
 	ctx: Context<'_>,
 	#[description = "Get a search URL to duckduckgo"] bang: String,
 ) -> Result<()> {
-	ctx.send(CreateReply::default().content(format!("https://duckduckgo.com/search?q={}", bang)))
-		.await?;
+	ctx.send(CreateReply::default().content(format!(
+		"https://duckduckgo.com/search?q={}",
+		bang.replace(" ", "%20")
+	)))
+	.await?;
 	Ok(())
 }
 
@@ -42,8 +45,11 @@ pub async fn google_bang(
 	ctx: Context<'_>,
 	#[description = "Get a search URL to google"] bang: String,
 ) -> Result<()> {
-	ctx.send(CreateReply::default().content(format!("https://google.com/search?q={}", bang)))
-		.await?;
+	ctx.send(CreateReply::default().content(format!(
+		"https://google.com/search?q={}",
+		bang.replace(" ", "%20")
+	)))
+	.await?;
 	Ok(())
 }
 
@@ -53,7 +59,10 @@ pub async fn wikipedia_bang(
 	ctx: Context<'_>,
 	#[description = "Get a search URL to wikipedia"] bang: String,
 ) -> Result<()> {
-	ctx.send(CreateReply::default().content(format!("https://en.wikipedia.org/wiki/{}", bang)))
-		.await?;
+	ctx.send(CreateReply::default().content(format!(
+		"https://en.wikipedia.org/wiki/{}",
+		bang.replace(" ", "%20")
+	)))
+	.await?;
 	Ok(())
 }

--- a/src/commands/bangs.rs
+++ b/src/commands/bangs.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use poise::CreateReply;
+
+use crate::types::Context;
+
+/// ShortHand for GitHub URLs
+#[poise::command(slash_command, prefix_command, rename = "gh")]
+pub async fn gh_bang(
+	ctx: Context<'_>,
+	#[description = "Prefix with `https://github.com/`"] bang: String,
+) -> Result<()> {
+	ctx.send(CreateReply::default().content(format!("https://github.com/{}", bang)))
+		.await?;
+	Ok(())
+}
+
+/// ShortHand for Codeberg URLs
+#[poise::command(slash_command, prefix_command, rename = "cb")]
+pub async fn codeberg_bang(
+	ctx: Context<'_>,
+	#[description = "Prefix with `https://codeberg.org/`"] bang: String,
+) -> Result<()> {
+	ctx.send(CreateReply::default().content(format!("https://codeberg.org/{}", bang)))
+		.await?;
+	Ok(())
+}
+
+/// ShortHand for DuckDuckGo Search URLs
+#[poise::command(slash_command, prefix_command, rename = "ddg")]
+pub async fn duckduckgo_bang(
+	ctx: Context<'_>,
+	#[description = "Get a search URL to duckduckgo"] bang: String,
+) -> Result<()> {
+	ctx.send(CreateReply::default().content(format!("https://duckduckgo.com/search?q={}", bang)))
+		.await?;
+	Ok(())
+}
+
+/// ShortHand for Google Search URLs
+#[poise::command(slash_command, prefix_command, rename = "gle")]
+pub async fn google_bang(
+	ctx: Context<'_>,
+	#[description = "Get a search URL to google"] bang: String,
+) -> Result<()> {
+	ctx.send(CreateReply::default().content(format!("https://google.com/search?q={}", bang)))
+		.await?;
+	Ok(())
+}
+
+/// ShortHand for Wikipedia URLs
+#[poise::command(slash_command, prefix_command, rename = "wiki")]
+pub async fn wikipedia_bang(
+	ctx: Context<'_>,
+	#[description = "Get a search URL to wikipedia"] bang: String,
+) -> Result<()> {
+	ctx.send(CreateReply::default().content(format!("https://en.wikipedia.org/wiki/{}", bang)))
+		.await?;
+	Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,11 @@ pub async fn serenity(
 fn build_command_list(enable_database: bool) -> Vec<poise::Command<Data, Error>> {
 	let mut command_list = vec![
 		commands::man::man(),
+		commands::bangs::gh_bang(),
+		commands::bangs::duckduckgo_bang(),
+		commands::bangs::codeberg_bang(),
+		commands::bangs::wikipedia_bang(),
+		commands::bangs::google_bang(),
 		commands::crates::crate_(),
 		commands::crates::doc(),
 		commands::godbolt::godbolt(),


### PR DESCRIPTION
Basically I'm tired of typing out:
`https://github.com/foo/bar` 
so now anyone can just 
/gh foo/bar
or 
/gh rust-lang
or 
/ddg how to code in rust (sends a link with search results of "how to code in rust")

This way its easier for someone to link repo's and other commonly referenced resources

Full list of bangs:
- GitHub (?gh)
- Codeberg (?cb)
- Google (?gle)
- DuckDuckGo (?ddg)
- WIkipedia (?wiki)

Each implementation is extremely simple thanks to poise and serenity doing the had work.

And as conrad asked, they're available as `/` commands as well. 

